### PR TITLE
Implement metadata ingest

### DIFF
--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,6 +1,16 @@
+"""Metadata ingestion script.
+
+Exports entity metadata from Home Assistant, creates OpenAI embeddings and
+upserts the result into ArangoDB. Only static metadata is stored, runtime
+state information is ignored.
+"""
+
+from __future__ import annotations
+
 import os
 import argparse
 import logging
+import time
 from typing import List, Optional
 
 import httpx
@@ -11,56 +21,97 @@ from arango import ArangoClient
 logger = logging.getLogger(__name__)
 
 
+def _retry_get(client: httpx.Client, url: str) -> httpx.Response:
+    """GET with up to three retries and exponential backoff."""
+
+    for attempt in range(3):
+        try:
+            resp = client.get(url)
+            resp.raise_for_status()
+            return resp
+        except Exception as exc:  # pragma: no cover - network errors
+            if attempt == 2:
+                raise
+            wait = 2**attempt
+            logger.warning("Retrying %s in %ss due to %s", url, wait, exc)
+            time.sleep(wait)
+
+
 def fetch_states(entity_id: Optional[str] = None) -> List[dict]:
+    """Fetch entity states from Home Assistant."""
+
     base_url = os.environ["HA_URL"]
     token = os.environ["HA_TOKEN"]
     headers = {"Authorization": f"Bearer {token}"}
+
     with httpx.Client(base_url=base_url, headers=headers, timeout=10.0) as client:
-        if entity_id:
-            resp = client.get(f"/api/states/{entity_id}")
-            resp.raise_for_status()
-            return [resp.json()]
-        resp = client.get("/api/states")
-        resp.raise_for_status()
-        return resp.json()
+        url = f"/api/states/{entity_id}" if entity_id else "/api/states"
+        resp = _retry_get(client, url)
+        data = resp.json()
+        return [data] if entity_id else data
 
 
 def build_text(entity: dict) -> str:
+    """Return the concatenated text used for embedding."""
+
     attrs = entity.get("attributes", {})
     friendly_name = attrs.get("friendly_name", "")
-    area = attrs.get("area", "")
+    area = attrs.get("area") or attrs.get("area_id", "")
     domain = entity.get("entity_id", "").split(".")[0]
     synonyms = " ".join(attrs.get("synonyms", []))
+
     return f"{friendly_name}. {area}. {domain}. {synonyms}".strip()
 
 
-def embed_text(text: str, client: openai.OpenAI) -> Optional[List[float]]:
-    try:
-        resp = client.embeddings.create(model="text-embedding-3-large", input=text)
-        return resp.data[0].embedding  # type: ignore[index]
-    except Exception as exc:  # pragma: no cover - network errors
-        logger.error("Embedding failed: %s", exc)
-        return None
+def embed_texts(texts: List[str], client: openai.OpenAI) -> List[List[float]]:
+    """Embed a batch of texts with retry and model fallback."""
+
+    model = "text-embedding-3-large"
+    for attempt in range(3):
+        try:
+            resp = client.embeddings.create(model=model, input=texts)
+            return [item.embedding for item in resp.data]  # type: ignore[index]
+        except Exception as exc:  # pragma: no cover - network errors
+            # Fallback to smaller model on quota errors
+            if "quota" in str(exc).lower() and model != "text-embedding-3-small":
+                logger.warning("Quota exceeded, falling back to small model")
+                model = "text-embedding-3-small"
+                continue
+
+            if attempt == 2:
+                raise
+            wait = 2**attempt
+            logger.warning("Embedding retry in %ss due to %s", wait, exc)
+            time.sleep(wait)
+
+    # Should not reach here but return empty embeddings in case of persistent errors
+    return [[] for _ in texts]
 
 
-def upsert_entity(entity: dict, embedding: List[float], collection):
+def build_doc(entity: dict, embedding: List[float]) -> dict:
+    """Construct the ArangoDB document for an entity."""
+
     attrs = entity.get("attributes", {})
-    doc = {
+    return {
         "_key": entity["entity_id"],
         "entity_id": entity["entity_id"],
-        "friendly_name": attrs.get("friendly_name"),
-        "area": attrs.get("area"),
         "domain": entity["entity_id"].split(".")[0],
+        "area": attrs.get("area") or attrs.get("area_id"),
+        "friendly_name": attrs.get("friendly_name"),
         "synonyms": attrs.get("synonyms"),
-        "text": build_text(entity),
         "embedding": embedding,
     }
-    collection.insert(doc, overwrite=True)
 
 
 def ingest(entity_id: Optional[str] = None) -> None:
+    """Run the ingestion process."""
+
     logging.basicConfig(level=logging.INFO)
+
     states = fetch_states(entity_id)
+    if not states:
+        return
+
     oai_client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
 
     arango = ArangoClient(hosts=os.environ["ARANGO_URL"])
@@ -68,14 +119,27 @@ def ingest(entity_id: Optional[str] = None) -> None:
     db = arango.db(db_name, username=os.environ["ARANGO_USER"], password=os.environ["ARANGO_PASS"])
     col = db.collection("entity")
 
-    for entity in states:
-        text = build_text(entity)
-        embedding = embed_text(text, oai_client)
-        if embedding is None:
-            logger.warning("Skipping entity %s", entity.get("entity_id"))
+    batch_size = 100
+    for i in range(0, len(states), batch_size):
+        batch = states[i : i + batch_size]
+        texts = [build_text(e) for e in batch]
+        try:
+            embeddings = embed_texts(texts, oai_client)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Skipping batch due to embedding error: %s", exc)
             continue
-        upsert_entity(entity, embedding, col)
-        logger.info("Upserted %s", entity.get("entity_id"))
+
+        docs = []
+        for ent, emb in zip(batch, embeddings):
+            if not emb:
+                logger.warning("Skipping entity %s", ent.get("entity_id"))
+                continue
+            docs.append(build_doc(ent, emb))
+
+        if docs:
+            col.insert_many(docs, overwrite=True, overwrite_mode="update")
+            for d in docs:
+                logger.info("Upserted %s", d["entity_id"])
 
 
 def cli() -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -44,4 +44,8 @@ def test_ingest_upserts(monkeypatch):
 
     ingest.ingest()
 
-    mock_collection.insert.assert_called_once()
+    mock_collection.insert_many.assert_called_once()
+    args, kwargs = mock_collection.insert_many.call_args
+    assert kwargs.get("overwrite") is True
+    docs = args[0]
+    assert docs[0]["embedding"]


### PR DESCRIPTION
## Summary
- extend `scripts/ingest.py` to export entity metadata from Home Assistant
- batch embed text via OpenAI with retries/fallback to small model
- upsert metadata in ArangoDB using `insert_many`
- update tests

## Testing
- `poetry run pytest -k ingest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794e787c508327bbf38cb967582f64