### PR TITLE
Extend ingest metadata

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+HA_URL=http://homeassistant.local:8123
+HA_TOKEN=your_ha_token
+ARANGO_URL=http://arangodb:8529
+ARANGO_DB=ha_graph
+ARANGO_USER=root
+ARANGO_PASS=secret
+OPENAI_API_KEY=your_openai_key

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -48,4 +48,15 @@ def test_ingest_upserts(monkeypatch):
     args, kwargs = mock_collection.insert_many.call_args
     assert kwargs.get("overwrite") is True
     docs = args[0]
-    assert docs[0]["embedding"]
+    doc = docs[0]
+    assert doc["embedding"]
+    expected_text = (
+        "Test. Kitchen. sensor. foo. living room nappali temperature h\u0151m\u00e9rs\u00e9klet"
+    )
+    assert doc["text"] == expected_text
+    import hashlib
+
+    assert (
+        doc["meta_hash"]
+        == hashlib.sha256(expected_text.encode()).hexdigest()
+    )


### PR DESCRIPTION
## Summary
- add extra manual synonyms in `build_text`
- include `text` and `meta_hash` in the ingested document
- provide `.env.sample` with required environment variables
- update tests for new fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879536acb4083278bae59626c31772e