### PR TITLE
Add flexible embedding backend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,4 @@ ARANGO_DB=ha_graph
 ARANGO_USER=root
 ARANGO_PASS=secret
 OPENAI_API_KEY=your_openai_key
+EMBEDDING_BACKEND=local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ uvicorn = "^0.35.0"
 httpx = "^0.27"
 openai = "^1.25.0"
 python-arango = "^7.9.0"
+sentence-transformers = "^2.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1"

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -22,6 +22,58 @@ from arango import ArangoClient
 logger = logging.getLogger(__name__)
 
 
+class EmbeddingBackend:
+    """Abstract embedding backend interface."""
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        """Return embeddings for the given texts."""
+        raise NotImplementedError
+
+
+class LocalBackend(EmbeddingBackend):
+    """Embed texts locally using SentenceTransformers."""
+
+    def __init__(self) -> None:
+        from sentence_transformers import SentenceTransformer
+
+        self.model = SentenceTransformer("all-MiniLM-L6-v2", device="cpu")
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        embeddings = self.model.encode(
+            texts,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+            normalize_embeddings=True,
+        )
+        return [e.tolist() for e in embeddings]
+
+
+class OpenAIBackend(EmbeddingBackend):
+    """Embed texts using the OpenAI API."""
+
+    def __init__(self) -> None:
+        self.client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        model = "text-embedding-3-large"
+        for attempt in range(3):
+            try:
+                resp = self.client.embeddings.create(model=model, input=texts)
+                return [item.embedding for item in resp.data]  # type: ignore[index]
+            except Exception as exc:  # pragma: no cover - network errors
+                if "quota" in str(exc).lower() and model != "text-embedding-3-small":
+                    logger.warning("Quota exceeded, falling back to small model")
+                    model = "text-embedding-3-small"
+                    continue
+
+                if attempt == 2:
+                    raise
+                wait = 2**attempt
+                logger.warning("Embedding retry in %ss due to %s", wait, exc)
+                time.sleep(wait)
+
+        return [[] for _ in texts]
+
 def _retry_get(client: httpx.Client, url: str) -> httpx.Response:
     """GET with up to three retries and exponential backoff."""
 
@@ -67,29 +119,6 @@ def build_text(entity: dict) -> str:
     return f"{friendly_name}. {area}. {domain}. {synonyms}. {extra_synonyms}".strip()
 
 
-def embed_texts(texts: List[str], client: openai.OpenAI) -> List[List[float]]:
-    """Embed a batch of texts with retry and model fallback."""
-
-    model = "text-embedding-3-large"
-    for attempt in range(3):
-        try:
-            resp = client.embeddings.create(model=model, input=texts)
-            return [item.embedding for item in resp.data]  # type: ignore[index]
-        except Exception as exc:  # pragma: no cover - network errors
-            # Fallback to smaller model on quota errors
-            if "quota" in str(exc).lower() and model != "text-embedding-3-small":
-                logger.warning("Quota exceeded, falling back to small model")
-                model = "text-embedding-3-small"
-                continue
-
-            if attempt == 2:
-                raise
-            wait = 2**attempt
-            logger.warning("Embedding retry in %ss due to %s", wait, exc)
-            time.sleep(wait)
-
-    # Should not reach here but return empty embeddings in case of persistent errors
-    return [[] for _ in texts]
 
 
 def build_doc(entity: dict, embedding: List[float], text: str) -> dict:
@@ -119,7 +148,12 @@ def ingest(entity_id: Optional[str] = None) -> None:
     if not states:
         return
 
-    oai_client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+    backend = os.getenv("EMBEDDING_BACKEND", "local").lower()
+    logger.info("Using embedding backend: %s", backend)
+    if backend == "openai":
+        emb_backend: EmbeddingBackend = OpenAIBackend()
+    else:
+        emb_backend = LocalBackend()
 
     arango = ArangoClient(hosts=os.environ["ARANGO_URL"])
     db_name = os.getenv("ARANGO_DB", "_system")
@@ -131,7 +165,7 @@ def ingest(entity_id: Optional[str] = None) -> None:
         batch = states[i : i + batch_size]
         texts = [build_text(e) for e in batch]
         try:
-            embeddings = embed_texts(texts, oai_client)
+            embeddings = emb_backend.embed(texts)
         except Exception as exc:  # pragma: no cover - network errors
             logger.warning("Skipping batch due to embedding error: %s", exc)
             continue

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -9,6 +9,7 @@ def test_ingest_upserts(monkeypatch):
         "HA_URL": "http://ha",
         "HA_TOKEN": "token",
         "OPENAI_API_KEY": "sk",
+        "EMBEDDING_BACKEND": "openai",
         "ARANGO_URL": "http://db",
         "ARANGO_USER": "root",
         "ARANGO_PASS": "pass",
@@ -29,11 +30,9 @@ def test_ingest_upserts(monkeypatch):
     mock_client.__enter__.return_value = mock_client
     monkeypatch.setattr(ingest.httpx, "Client", MagicMock(return_value=mock_client))
 
-    embed_resp = MagicMock()
-    embed_resp.data = [MagicMock(embedding=[0.0] * 1536)]
-    mock_oai = MagicMock()
-    mock_oai.embeddings.create.return_value = embed_resp
-    monkeypatch.setattr(ingest.openai, "OpenAI", MagicMock(return_value=mock_oai))
+    mock_backend = MagicMock()
+    mock_backend.embed.return_value = [[0.0] * 1536]
+    monkeypatch.setattr(ingest, "OpenAIBackend", MagicMock(return_value=mock_backend))
 
     mock_collection = MagicMock()
     mock_db = MagicMock()


### PR DESCRIPTION
## Summary
- implement backend classes for embeddings
- select embedding backend from `EMBEDDING_BACKEND`
- default to local MiniLM model using CPU
- document new variable in `.env.sample`
- add `sentence-transformers` dependency
- update ingest tests for new backend

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879643529648327bcf4b4435f02550b