### PR TITLE
Add ArangoDB migrations and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: migrate
+migrate:
+	arangosh --server.endpoint $$ARANGO_URL \
+	         --server.username $$ARANGO_USER \
+	         --server.password $$ARANGO_PASS \
+	         --javascript.execute migrations/001_init_collections.arangodb

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Set `EMBEDDING_PROVIDER` to choose how text embeddings are created. Valid values
 - `local` – runs on CPU using the MiniLM model from the `sentence-transformers` package.
 - `openai` – uses the OpenAI API with your `OPENAI_API_KEY`.
 
+Run `make migrate` to set up the database.

--- a/migrations/001_init_collections.arangodb
+++ b/migrations/001_init_collections.arangodb
@@ -1,0 +1,74 @@
+'use strict';
+const db = require('@arangodb').db;
+
+function ensureDocumentCollection(name) {
+  if (!db._collection(name)) {
+    db._createDocumentCollection(name);
+  }
+  return db._collection(name);
+}
+
+function ensureEdgeCollection(name) {
+  if (!db._collection(name)) {
+    db._createEdgeCollection(name);
+  }
+  return db._collection(name);
+}
+
+// Document collections
+const docCols = ['area','device','entity','automation','scene','person','event','knowledge'];
+for (const col of docCols) {
+  ensureDocumentCollection(col);
+}
+
+// Edge collection
+ensureEdgeCollection('edge');
+
+// Indexes
+const entity = db._collection('entity');
+if (!entity.getIndexes().some(i => i.type === 'hash' && i.fields[0] === 'entity_id')) {
+  entity.ensureIndex({ type: 'hash', fields: ['entity_id'], unique: true });
+}
+if (!entity.getIndexes().some(i => i.type === 'hnsw' && i.fields[0] === 'embedding')) {
+  entity.ensureIndex({ type: 'hnsw', fields: ['embedding'], dimensions: 1536, metric: 'cosine' });
+}
+
+const edge = db._collection('edge');
+if (!edge.getIndexes().some(i => i.type === 'hash' && i.fields[0] === 'label')) {
+  edge.ensureIndex({ type: 'hash', fields: ['label'] });
+}
+
+const event = db._collection('event');
+if (!event.getIndexes().some(i => i.type === 'ttl' && i.fields[0] === 'ts')) {
+  event.ensureIndex({ type: 'ttl', fields: ['ts'], expireAfter: 30 * 24 * 3600 });
+}
+
+// ArangoSearch view
+const viewProps = {
+  links: {
+    entity: {
+      includeAllFields: false,
+      storeValues: 'none',
+      fields: {
+        text: { analyzers: ['text_en'] },
+        embedding: { analyzers: ['vector'], vector: { dimension: 1536, metric: 'cosine' } }
+      },
+      features: ['frequency', 'norm', 'position']
+    },
+    area: {
+      fields: {
+        name: { analyzers: ['text_en'] },
+        synonyms: { analyzers: ['text_en'] }
+      }
+    }
+  }
+};
+
+if (!db._view('v_meta')) {
+  db._createView('v_meta', 'arangosearch', viewProps);
+} else {
+  db._view('v_meta').properties(viewProps, true);
+}
+
+console.log('Migration 001 completed');
+


### PR DESCRIPTION
## Summary
- add idempotent `migrations/001_init_collections.arangodb`
- provide `migrate` target in Makefile
- mention migration in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687a16f7d7688327ba3db7a14170b72d