### PR TITLE
Add edge batch creation to ingest

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -67,7 +67,9 @@ def test_ingest_upserts(monkeypatch):
 
     mock_edge_col.insert_many.assert_called()
     edge_docs = mock_edge_col.insert_many.call_args[0][0]
+    assert len(edge_docs) >= 1
     assert any(e["label"] == "area_contains" for e in edge_docs)
+    assert all(e["created_by"] == "ingest" for e in edge_docs)
     assert doc["text"] == expected_text
     import hashlib
 


### PR DESCRIPTION
## Summary
- generate `area_contains` and `device_hosts` edges during entity ingest
- record creator and timestamp for each edge
- adjust ingest unit test to check new edges

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3b163d948327bb8c36e08ec550a4