### PR TITLE
Add process-request endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ Run the realtime watcher to ingest entity metadata whenever it changes:
 python scripts/watch_entities.py
 # add --debug for verbose output
 ```
+
+## Process requests
+
+Example usage:
+
+```bash
+curl -X POST http://localhost:8000/process-request \
+    -H 'Content-Type: application/json' \
+    -d '{"user_message":"Kapcsold le a nappali lámpát!"}'
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,79 @@
-from fastapi import FastAPI
+import os
+from fastapi import FastAPI, APIRouter, HTTPException
+
+from arango import ArangoClient
+
+from . import schemas
+from scripts.ingest import LocalBackend, OpenAIBackend, EmbeddingBackend
 
 app = FastAPI()
+router = APIRouter()
 
-@app.get("/health")
+
+@router.get("/health")
 async def health():
     return {"status": "ok"}
+
+
+@router.post("/process-request", response_model=schemas.ProcessResponse)
+async def process_request(payload: schemas.Request):
+    backend = os.getenv("EMBEDDING_BACKEND", "local").lower()
+    if backend == "openai":
+        emb_backend: EmbeddingBackend = OpenAIBackend()
+    else:
+        emb_backend = LocalBackend()
+
+    try:
+        query_vector = emb_backend.embed([payload.user_message])[0]
+    except Exception as exc:  # pragma: no cover - backend errors
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    arango = ArangoClient(hosts=os.environ["ARANGO_URL"])
+    db_name = os.getenv("ARANGO_DB", "_system")
+    db = arango.db(
+        db_name,
+        username=os.environ["ARANGO_USER"],
+        password=os.environ["ARANGO_PASS"],
+    )
+
+    aql = (
+        "FOR e IN v_meta "
+        "SEARCH ANALYZER("
+        "SIMILARITY(e.embedding, @qv) > 0.7 "
+        "OR PHRASE(e.text, @msg, \"text_en\")"
+        ", \"text_en\") "
+        "SORT BM25(e) DESC "
+        "LIMIT 5 "
+        "RETURN e"
+    )
+    try:
+        cursor = db.aql.execute(aql, bind_vars={"qv": query_vector, "msg": payload.user_message})
+        results = list(cursor)
+    except Exception as exc:  # pragma: no cover - db errors
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    ids = [doc.get("entity_id") for doc in results]
+    comma_sep = ",".join(ids)
+    system_prompt = "You are a Home Assistant agent.\n" f"Relevant entities: {comma_sep}\n"
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "homeassistant.turn_on",
+            "parameters": {
+                "type": "object",
+                "properties": {"entity_id": {"type": "string"}},
+                "required": ["entity_id"],
+            },
+        },
+    }]
+
+    return {
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": payload.user_message},
+        ],
+        "tools": tools,
+    }
+
+
+app.include_router(router)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import List, Dict
+
+
+class Request(BaseModel):
+    user_message: str
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ProcessResponse(BaseModel):
+    messages: List[ChatMessage]
+    tools: List[Dict]

--- a/tests/test_process_request.py
+++ b/tests/test_process_request.py
@@ -1,0 +1,43 @@
+import os
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+from app.main import app
+import app.main as main
+
+client = TestClient(app)
+
+
+def test_process_request(monkeypatch):
+    os.environ.update({
+        "ARANGO_URL": "http://db",
+        "ARANGO_USER": "root",
+        "ARANGO_PASS": "pass",
+        "EMBEDDING_BACKEND": "local",
+    })
+
+    mock_backend = MagicMock()
+    mock_backend.embed.return_value = [[0.0] * 1536]
+    monkeypatch.setattr(main, "LocalBackend", MagicMock(return_value=mock_backend))
+
+    docs = [
+        {"entity_id": "sensor.kitchen_temp"},
+        {"entity_id": "light.livingroom"},
+        {"entity_id": "switch.bedroom"},
+    ]
+
+    mock_cursor = MagicMock()
+    mock_cursor.__iter__.return_value = docs
+    mock_db = MagicMock()
+    mock_db.aql.execute.return_value = mock_cursor
+    mock_arango = MagicMock()
+    mock_arango.db.return_value = mock_db
+    monkeypatch.setattr(main, "ArangoClient", MagicMock(return_value=mock_arango))
+
+    resp = client.post("/process-request", json={"user_message": "Kapcsold le a nappali lámpát!"})
+    assert resp.status_code == 200
+    data = resp.json()
+    system = data["messages"][0]["content"]
+    assert "sensor.kitchen_temp" in system
+    assert "light.livingroom" in system
+    assert "switch.bedroom" in system
+    assert isinstance(data.get("tools"), list) and data["tools"]


### PR DESCRIPTION
## Summary
- implement POST /process-request with hybrid ArangoSearch retrieval
- add schemas for request/response
- create unit test for process_request
- document example curl usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4d0b64448327b69a2821229f9083