### PR TITLE
Improve Influx state retrieval reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ curl -X POST /process-request -d '{"user_message":"Kapcsold fel a nappali lámp�
 
 Enable the official *InfluxDB* addon in Home Assistant and create a read-only token.
 Add the connection details to your `.env` file (see `.env.sample`) and run `docker-compose up -d influxdb` to start a local instance.
+
+### Influx config & caching
+
+- `INFLUX_MEASUREMENT=""`  # üres, ha a HA addon üres measurementre ír
+- Cache TTL: 30 s (változtatható az env-ben)

--- a/app/main.py
+++ b/app/main.py
@@ -128,10 +128,12 @@ async def process_request(payload: schemas.Request):
 
     if results:
         top = results[0]
-        if top.get("domain") == "sensor" and top.get("unit_of_measurement"):
+        if top.get("domain") == "sensor":
             last = get_last_state(top.get("entity_id"))
             if last is not None:
-                system_prompt += f"Current value of {top['entity_id']}: {last}\n"
+                system_prompt += (
+                    f"Current value of {top['entity_id'].lower()}: {last}\n"
+                )
 
     if intent == "control" and any(d.get("domain") in CONTROL_DOMAINS for d in results):
         tools = [TURN_ON_TOOL, TURN_OFF_TOOL]

--- a/poetry.lock
+++ b/poetry.lock
@@ -33,6 +33,17 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
+    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+]
+
+[[package]]
 name = "certifi"
 version = "2025.7.14"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -407,6 +418,30 @@ enabler = ["pytest-enabler (>=2.2)"]
 perf = ["ipython"]
 test = ["flufl.flake8", "importlib_resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
 type = ["pytest-mypy"]
+
+[[package]]
+name = "influxdb-client"
+version = "1.49.0"
+description = "InfluxDB 2.0 Python client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "influxdb_client-1.49.0-py3-none-any.whl", hash = "sha256:b3a688f02cdf18e17ec08ef35bee489fdb90e4e5969bd0a8dd1a8657a66d892b"},
+    {file = "influxdb_client-1.49.0.tar.gz", hash = "sha256:4a53a218adef6ac9458bfbd31fa08c76194f70310c6b4e01f53d804bd2c48e03"},
+]
+
+[package.dependencies]
+certifi = ">=14.05.14"
+python-dateutil = ">=2.5.3"
+reactivex = ">=4.0.4"
+setuptools = ">=21.0.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+async = ["aiocsv (>=1.2.2)", "aiohttp (>=3.8.1)"]
+ciso = ["ciso8601 (>=2.1.1)"]
+extra = ["numpy", "pandas (>=1.0.0)"]
+test = ["aioresponses (>=0.7.3)", "coverage (>=4.0.3)", "flake8 (>=5.0.3)", "httpretty (==1.0.5)", "jinja2 (>=3.1.4)", "nose (>=1.3.7)", "pluggy (>=0.3.1)", "psutil (>=5.6.3)", "py (>=1.4.31)", "pytest (>=5.0.0)", "pytest-cov (>=3.0.0)", "pytest-timeout (>=2.1.0)", "randomize (>=0.13)", "sphinx (==1.8.5)", "sphinx-rtd-theme"]
 
 [[package]]
 name = "iniconfig"
@@ -1297,6 +1332,20 @@ urllib3 = ">=1.26.0"
 dev = ["black (>=22.3.0)", "flake8 (>=4.0.1)", "isort (>=5.10.1)", "mock", "mypy (>=0.942)", "pre-commit (>=2.17.0)", "pytest (>=7.1.1)", "pytest-cov (>=3.0.0)", "sphinx", "sphinx-rtd-theme", "types-pkg-resources", "types-requests", "types-setuptools"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -1357,6 +1406,20 @@ files = [
     {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
     {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
+
+[[package]]
+name = "reactivex"
+version = "4.0.4"
+description = "ReactiveX (Rx) for Python"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "reactivex-4.0.4-py3-none-any.whl", hash = "sha256:0004796c420bd9e68aad8e65627d85a8e13f293de76656165dffbcb3a0e3fb6a"},
+    {file = "reactivex-4.0.4.tar.gz", hash = "sha256:e912e6591022ab9176df8348a653fe8c8fa7a301f26f9931c9d8c78a650e04e8"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.1.1,<5.0.0"
 
 [[package]]
 name = "regex"
@@ -1680,6 +1743,17 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
 type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.14.*)", "pytest-mypy"]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
 
 [[package]]
 name = "sniffio"
@@ -2110,4 +2184,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "cd53d4dc66ee547e73c7e5d94507d55ca2c3d62297bc4dc260ef5942cb9ff069"
+content-hash = "3e2b8a1f723a23d8f314613d0b33cdd3b99d56a375fd5859737bbb464194f747"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python-arango = "^7.9.0"
 sentence-transformers = "^2.2"
 websockets = "^12.0"
 influxdb-client = "^1.40"
+cachetools = "^5.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1"

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -49,6 +49,7 @@ def test_adaptive_read_no_tools(monkeypatch):
     monkeypatch.setattr(main, "ArangoClient", MagicMock())
     ents = [{"entity_id": "sensor.temp", "domain": "sensor"}]
     monkeypatch.setattr(main, "retrieve_entities", MagicMock(return_value=ents))
+    monkeypatch.setattr(main, "get_last_state", MagicMock(return_value=None))
 
     resp = client.post("/process-request", json={"user_message": "Hány fok van a nappaliban?"})
     assert resp.status_code == 200

--- a/tests/test_process_request.py
+++ b/tests/test_process_request.py
@@ -32,6 +32,7 @@ def test_process_request(monkeypatch):
     mock_arango = MagicMock()
     mock_arango.db.return_value = mock_db
     monkeypatch.setattr(main, "ArangoClient", MagicMock(return_value=mock_arango))
+    monkeypatch.setattr(main, "get_last_state", MagicMock(return_value=None))
 
     resp = client.post("/process-request", json={"user_message": "Kapcsold le a nappali lámpát!"})
     assert resp.status_code == 200

--- a/tests/test_state_service.py
+++ b/tests/test_state_service.py
@@ -12,11 +12,13 @@ def setup_env():
         "HA_TOKEN": "token",
         "INFLUX_URL": "http://db:8086",
         "INFLUX_TOKEN": "tok",
+        "STATE_CACHE_TTL": "30",
     })
 
 
 def test_influx_success(monkeypatch):
     setup_env()
+    ss.get_last_state.cache.clear()
     mock_record = MagicMock()
     mock_record.get_value.return_value = 23.9
     mock_record.values = {"unit_of_measurement": "°C"}
@@ -34,6 +36,7 @@ def test_influx_success(monkeypatch):
 
 def test_fallback_to_ha(monkeypatch):
     setup_env()
+    ss.get_last_state.cache.clear()
     monkeypatch.setattr(ss, "InfluxDBClient", MagicMock(side_effect=Exception))
     resp = MagicMock(status_code=200)
     resp.json.return_value = {"state": "22", "attributes": {"unit_of_measurement": "°C"}}
@@ -44,3 +47,48 @@ def test_fallback_to_ha(monkeypatch):
     monkeypatch.setattr(ss.httpx, "Client", MagicMock(return_value=client))
     val = ss.get_last_state("sensor.temp")
     assert val == "22 °C"
+
+
+def test_cache_hit(monkeypatch):
+    setup_env()
+    ss.get_last_state.cache.clear()
+
+    calls = []
+
+    def fake_influx(eid):
+        calls.append(eid)
+        return "1"
+
+    monkeypatch.setattr(ss, "_query_influx", fake_influx)
+    monkeypatch.setattr(ss, "_query_ha_state", MagicMock(return_value=None))
+
+    first = ss.get_last_state("sensor.temp")
+    second = ss.get_last_state("sensor.temp")
+
+    assert first == "1"
+    assert second == "1"
+    assert calls == ["sensor.temp"]
+
+
+def test_empty_measurement_query(monkeypatch):
+    setup_env()
+    ss.get_last_state.cache.clear()
+    os.environ["INFLUX_MEASUREMENT"] = ""
+
+    captured = {}
+    query_api = MagicMock()
+
+    def fake_query(q):
+        captured["query"] = q
+        return []
+
+    query_api.query.side_effect = fake_query
+    mock_client = MagicMock()
+    mock_client.query_api.return_value = query_api
+    cm = MagicMock()
+    cm.__enter__.return_value = mock_client
+    monkeypatch.setattr(ss, "InfluxDBClient", MagicMock(return_value=cm))
+
+    ss._query_influx("sensor.temp")
+
+    assert "_measurement" not in captured["query"]


### PR DESCRIPTION
## Summary
- use cachetools TTL cache for state retrieval
- skip measurement filter when INFLUX_MEASUREMENT is empty
- standardise sensor state prompt
- log Influx query exceptions
- add cachetools dependency
- document Influx configuration and caching
- test cache behaviour and query generation

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `make migrate` *(fails: arangosh not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a69eed3308327a3e47e2a9368251b