### PR TITLE
Implement POST /process-response

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Example usage:
 curl -X POST /process-request -d '{"user_message":"Kapcsold fel a nappali lámpát"}'
 ```
 
+## Process responses
+
+Execute the returned tool-calls:
+
+```bash
+curl -X POST /process-response -d '{"id":"1","choices":[{"message":{"role":"assistant","content":"Felkapcsoltam a lámpát.","tool_calls":[{"id":"c1","type":"function","function":{"name":"homeassistant.turn_on","arguments":"{\"entity_id\":\"light.kitchen\"}"}}]}}]}'
+```
+
 ## InfluxDB integration
 
 Enable the official *InfluxDB* addon in Home Assistant and create a read-only token.

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -14,3 +14,34 @@ class ChatMessage(BaseModel):
 class ProcessResponse(BaseModel):
     messages: List[ChatMessage]
     tools: List[Dict]
+
+
+class LLMToolFunction(BaseModel):
+    name: str
+    arguments: str
+
+
+class LLMToolCall(BaseModel):
+    id: str
+    type: str
+    function: LLMToolFunction
+
+
+class LLMMessage(BaseModel):
+    role: str
+    content: str
+    tool_calls: List[LLMToolCall] | None = None
+
+
+class LLMChoice(BaseModel):
+    message: LLMMessage
+
+
+class LLMResponse(BaseModel):
+    id: str
+    choices: List[LLMChoice]
+
+
+class ExecResult(BaseModel):
+    status: str
+    message: str

--- a/tests/test_process_response.py
+++ b/tests/test_process_response.py
@@ -1,0 +1,88 @@
+import os
+import json
+import httpx
+from fastapi.testclient import TestClient
+import app.main as main
+
+def setup_env():
+    os.environ.update({
+        "HA_URL": "http://ha",
+        "HA_TOKEN": "tok",
+    })
+
+
+def make_payload(content="OK", entity="light.test", func="homeassistant.turn_on"):
+    return {
+        "id": "1",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {
+                                "name": func,
+                                "arguments": json.dumps({"entity_id": entity})
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+
+def test_process_response_success(monkeypatch):
+    setup_env()
+    captured = []
+
+    def handler(request):
+        captured.append((request.url.path, json.loads(request.content.decode())))
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    class FakeHTTPX:
+        def __init__(self, real):
+            self._real = real
+            self.Response = real.Response
+
+        def AsyncClient(self, **kw):
+            kw["transport"] = transport
+            return self._real.AsyncClient(**kw)
+
+    monkeypatch.setattr(main, "httpx", FakeHTTPX(httpx))
+
+    client = TestClient(main.app)
+    resp = client.post("/process-response", json=make_payload())
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "message": "OK"}
+    assert captured == [("/api/services/homeassistant/turn_on", {"entity_id": "light.test"})]
+
+
+def test_process_response_error(monkeypatch):
+    setup_env()
+
+    def handler(request):
+        return httpx.Response(500)
+
+    transport = httpx.MockTransport(handler)
+    class FakeHTTPX:
+        def __init__(self, real):
+            self._real = real
+            self.Response = real.Response
+
+        def AsyncClient(self, **kw):
+            kw["transport"] = transport
+            return self._real.AsyncClient(**kw)
+
+    monkeypatch.setattr(main, "httpx", FakeHTTPX(httpx))
+
+    client = TestClient(main.app)
+    resp = client.post("/process-response", json=make_payload(entity="light.fail"))
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "error", "message": "Nem sikerült végrehajtani: light.fail"}
+
+


### PR DESCRIPTION
## Summary
- add `/process-response` endpoint to execute tool-calls
- extend pydantic schemas for LLM responses and executor result
- provide REST executor tests using `httpx.MockTransport`
- document process-response usage

## Testing
- `pytest -k process_response -q`

------
https://chatgpt.com/codex/tasks/task_e_687a72393c1c8327bd513ffd5311914c