### PR TITLE
Add graph edge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Execute the returned tool-calls:
 curl -X POST /process-response -d '{"id":"1","choices":[{"message":{"role":"assistant","content":"Felkapcsoltam a lámpát.","tool_calls":[{"id":"c1","type":"function","function":{"name":"homeassistant.turn_on","arguments":"{\"entity_id\":\"light.kitchen\"}"}}]}}]}'
 ```
 
+## Add graph edge
+
+```bash
+curl -X POST :8000/graph/edge \
+  -H 'Content-Type: application/json' \
+  -d '{"_from":"area/nappali","_to":"area/etkezo","label":"area_adjacent"}'
+```
+
 ## InfluxDB integration
 
 Enable the official *InfluxDB* addon in Home Assistant and create a read-only token.

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,8 @@ import re
 import json
 from typing import List, Sequence
 from fastapi import FastAPI, APIRouter, HTTPException
+
+from .routers.graph import router as graph_router
 import httpx
 
 from arango import ArangoClient
@@ -188,3 +190,4 @@ async def process_response(payload: schemas.LLMResponse):
 
 
 app.include_router(router)
+app.include_router(graph_router)

--- a/app/routers/graph.py
+++ b/app/routers/graph.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from fastapi import APIRouter, HTTPException, Request
+from arango import ArangoClient
+
+from .. import schemas
+
+router = APIRouter()
+
+
+def _doc_exists(db, doc_id: str) -> bool:
+    if '/' not in doc_id:
+        return False
+    col_name, _ = doc_id.split('/', 1)
+    return db.collection(col_name).has(doc_id)
+
+
+@router.post('/graph/edge', response_model=schemas.EdgeResult)
+async def add_edge(edge: schemas.EdgeCreate, request: Request) -> schemas.EdgeResult:
+    arango = ArangoClient(hosts=os.environ['ARANGO_URL'])
+    db_name = os.getenv('ARANGO_DB', '_system')
+    db = arango.db(db_name, username=os.environ['ARANGO_USER'], password=os.environ['ARANGO_PASS'])
+    if not _doc_exists(db, edge._from):
+        raise HTTPException(status_code=422, detail='_from not found')
+    if not _doc_exists(db, edge._to):
+        raise HTTPException(status_code=422, detail='_to not found')
+
+    edge_key = f"{edge._from.replace('/', '_')}-{edge._to.replace('/', '_')}-{edge.label}"
+    edge_doc = {
+        '_key': edge_key,
+        '_from': edge._from,
+        '_to': edge._to,
+        'label': edge.label,
+        'weight': edge.weight,
+        'source': edge.source or request.headers.get('X-Caller', 'api'),
+        'ts_created': edge.ts_created or datetime.utcnow().isoformat(),
+    }
+    edge_coll = db.collection('edge')
+    result = edge_coll.insert(edge_doc, overwrite=True, overwrite_mode='update')
+    action = 'updated' if '_old_rev' in result else 'inserted'
+    return {'status': 'ok', 'edge_key': edge_key, 'action': action}
+

--- a/app/routers/graph.py
+++ b/app/routers/graph.py
@@ -22,16 +22,16 @@ async def add_edge(edge: schemas.EdgeCreate, request: Request) -> schemas.EdgeRe
     arango = ArangoClient(hosts=os.environ['ARANGO_URL'])
     db_name = os.getenv('ARANGO_DB', '_system')
     db = arango.db(db_name, username=os.environ['ARANGO_USER'], password=os.environ['ARANGO_PASS'])
-    if not _doc_exists(db, edge._from):
+    if not _doc_exists(db, edge.from_):
         raise HTTPException(status_code=422, detail='_from not found')
-    if not _doc_exists(db, edge._to):
+    if not _doc_exists(db, edge.to):
         raise HTTPException(status_code=422, detail='_to not found')
 
-    edge_key = f"{edge._from.replace('/', '_')}-{edge._to.replace('/', '_')}-{edge.label}"
+    edge_key = f"{edge.from_.replace('/', '_')}-{edge.to.replace('/', '_')}-{edge.label}"
     edge_doc = {
         '_key': edge_key,
-        '_from': edge._from,
-        '_to': edge._to,
+        '_from': edge.from_,
+        '_to': edge.to,
         'label': edge.label,
         'weight': edge.weight,
         'source': edge.source or request.headers.get('X-Caller', 'api'),

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import List, Dict
 
 
@@ -45,3 +45,27 @@ class LLMResponse(BaseModel):
 class ExecResult(BaseModel):
     status: str
     message: str
+
+class EdgeCreate(BaseModel):
+    _from: str
+    _to: str
+    label: str
+    weight: float = 1.0
+    source: str | None = None
+    ts_created: str | None = None
+
+    @field_validator('label')
+    @classmethod
+    def _valid_label(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError('label must not be empty')
+        if len(v) > 30:
+            raise ValueError('label too long')
+        return v
+
+
+class EdgeResult(BaseModel):
+    status: str
+    edge_key: str
+    action: str
+

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, ConfigDict, Field
 from typing import List, Dict
 
 
@@ -47,8 +47,9 @@ class ExecResult(BaseModel):
     message: str
 
 class EdgeCreate(BaseModel):
-    _from: str
-    _to: str
+    model_config = ConfigDict(populate_by_name=True)
+    from_: str = Field(alias="_from")
+    to: str = Field(alias="_to")
     label: str
     weight: float = 1.0
     source: str | None = None

--- a/tests/test_graph_edge.py
+++ b/tests/test_graph_edge.py
@@ -1,0 +1,68 @@
+import os
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+
+from app.main import app
+import app.routers.graph as graph
+
+client = TestClient(app)
+
+os.environ.update({
+    'ARANGO_URL': 'http://db',
+    'ARANGO_USER': 'root',
+    'ARANGO_PASS': 'pass',
+})
+
+EDGE_PAYLOAD = {
+    '_from': 'area/nappali',
+    '_to': 'area/etkezo',
+    'label': 'area_adjacent'
+}
+
+
+def setup_db(monkeypatch, insert_side_effect=None, has_side_effect=None):
+    mock_edge_col = MagicMock()
+    mock_edge_col.insert.side_effect = insert_side_effect
+    mock_area_col = MagicMock()
+    mock_area_col.has.side_effect = has_side_effect or (lambda *_: True)
+
+    def get_collection(name):
+        if name == 'edge':
+            return mock_edge_col
+        return mock_area_col
+
+    mock_db = MagicMock()
+    mock_db.collection.side_effect = get_collection
+    mock_arango = MagicMock()
+    mock_arango.db.return_value = mock_db
+    monkeypatch.setattr(graph, 'ArangoClient', MagicMock(return_value=mock_arango))
+    return mock_edge_col, mock_area_col
+
+
+def test_add_edge_insert(monkeypatch):
+    insert_result = {}
+    mock_edge_col, _ = setup_db(monkeypatch, insert_side_effect=[insert_result])
+    resp = client.post('/graph/edge', json=EDGE_PAYLOAD)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['action'] == 'inserted'
+    assert data['edge_key'] == 'area_nappali-area_etkezo-area_adjacent'
+    mock_edge_col.insert.assert_called_once()
+
+
+def test_add_edge_update(monkeypatch):
+    insert_results = [{}, {'_old_rev': '1'}]
+    mock_edge_col, _ = setup_db(monkeypatch, insert_side_effect=insert_results)
+    resp1 = client.post('/graph/edge', json=EDGE_PAYLOAD)
+    resp2 = client.post('/graph/edge', json=EDGE_PAYLOAD)
+    assert resp1.json()['action'] == 'inserted'
+    assert resp2.json()['action'] == 'updated'
+    assert mock_edge_col.insert.call_count == 2
+
+
+def test_add_edge_invalid_from(monkeypatch):
+    mock_edge_col, mock_area_col = setup_db(monkeypatch, has_side_effect=[False, True])
+    resp = client.post('/graph/edge', json=EDGE_PAYLOAD)
+    assert resp.status_code == 422
+    mock_edge_col.insert.assert_not_called()
+


### PR DESCRIPTION
## Summary
- add `EdgeCreate` and `EdgeResult` schemas
- implement `/graph/edge` route in new router
- hook the router into the FastAPI app
- add README example
- test insert/update/update-error cases

## Testing
- `pytest -k graph_edge -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687a8c04f0008327b5da042faa17fc21