### PR TITLE
Dynamic service catalog for Home Assistant

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,4 @@ INFLUX_TOKEN=your_token
 INFLUX_ORG=homeassistant
 INFLUX_BUCKET=homeassistant
 INFLUX_MEASUREMENT=measurement
+SERVICE_CACHE_TTL=21600

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ Add the connection details to your `.env` file (see `.env.sample`) and run `dock
 
 - `INFLUX_MEASUREMENT=""`  # üres, ha a HA addon üres measurementre ír
 - Cache TTL: 30 s (változtatható az env-ben)
+
+### Service cache
+The catalog of `/api/services` is fetched on first request and cached for 6 h
+(configurable via `SERVICE_CACHE_TTL`).

--- a/app/services/service_catalog.py
+++ b/app/services/service_catalog.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import time
+import asyncio
+import logging
+from typing import Dict, Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class ServiceCatalog:
+    """Cache Home Assistant services fetched from /api/services."""
+
+    def __init__(self, ttl: int = 6 * 3600) -> None:
+        self.ttl = ttl
+        self._cache: Dict[str, Dict[str, dict]] = {}
+        self._ts = 0.0
+        self._lock = asyncio.Lock()
+
+    async def refresh(self) -> None:
+        """Fetch and cache available services from Home Assistant."""
+        base_url = os.environ.get("HA_URL")
+        token = os.environ.get("HA_TOKEN")
+        if not base_url or not token:
+            logger.warning("Missing HA_URL or HA_TOKEN; service catalog empty")
+            self._cache = {}
+            self._ts = time.time()
+            return
+
+        headers = {"Authorization": f"Bearer {token}"}
+        async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=5.0) as client:
+            resp = await client.get("/api/services")
+            resp.raise_for_status()
+            data = resp.json()
+
+        catalog: Dict[str, Dict[str, dict]] = {}
+        for item in data:
+            domain = item.get("domain")
+            services = item.get("services", {})
+            if not domain:
+                continue
+            cat_services: Dict[str, dict] = {}
+            for name, spec in services.items():
+                fields = spec.get("fields", {})
+                cat_services[name] = {"fields": fields}
+            catalog[domain] = cat_services
+
+        self._cache = catalog
+        self._ts = time.time()
+        logger.debug("Service catalog refreshed with %d domains", len(catalog))
+
+    async def _ensure_fresh(self) -> None:
+        if time.time() - self._ts > self.ttl:
+            async with self._lock:
+                if time.time() - self._ts > self.ttl:
+                    await self.refresh()
+
+    async def get_service(self, domain: str, name: str) -> dict | None:
+        await self._ensure_fresh()
+        return self._cache.get(domain, {}).get(name)
+
+    async def get_domain_services(self, domain: str) -> Dict[str, dict]:
+        await self._ensure_fresh()
+        return self._cache.get(domain, {})

--- a/tests/test_process_response.py
+++ b/tests/test_process_response.py
@@ -11,7 +11,7 @@ def setup_env():
     })
 
 
-def make_payload(content="OK", entity="light.test", func="homeassistant.turn_on"):
+def make_payload(content="OK", entity="light.test", func="light.turn_on"):
     return {
         "id": "1",
         "choices": [
@@ -59,7 +59,7 @@ def test_process_response_success(monkeypatch):
     resp = client.post("/process-response", json=make_payload())
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok", "message": "OK"}
-    assert captured == [("/api/services/homeassistant/turn_on", {"entity_id": "light.test"})]
+    assert captured == [("/api/services/light/turn_on", {"entity_id": "light.test"})]
 
 
 def test_process_response_error(monkeypatch):

--- a/tests/test_service_catalog.py
+++ b/tests/test_service_catalog.py
@@ -1,0 +1,87 @@
+import os
+import httpx
+import pytest
+
+from app.services.service_catalog import ServiceCatalog
+from app.main import service_to_tool
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_tool_schema(monkeypatch):
+    os.environ.update({"HA_URL": "http://ha", "HA_TOKEN": "tok"})
+
+    resp_data = [
+        {
+            "domain": "light",
+            "services": {
+                "turn_on": {
+                    "fields": {
+                        "entity_id": {"required": True, "type": "string"},
+                        "brightness_pct": {"required": False, "type": "integer"},
+                    }
+                }
+            },
+        }
+    ]
+
+    async def handler(request):
+        assert request.url.path == "/api/services"
+        return httpx.Response(200, json=resp_data)
+
+    transport = httpx.MockTransport(handler)
+
+    class FakeHTTPX:
+        def __init__(self, real):
+            self._real = real
+            self.Response = real.Response
+
+        def AsyncClient(self, **kw):
+            kw["transport"] = transport
+            return self._real.AsyncClient(**kw)
+
+    import app.services.service_catalog as sc
+
+    monkeypatch.setattr(sc, "httpx", FakeHTTPX(httpx))
+
+    cat = ServiceCatalog(ttl=60)
+    await cat.refresh()
+    spec = await cat.get_service("light", "turn_on")
+    assert "brightness_pct" in spec["fields"]
+
+    tool = service_to_tool("light", "turn_on", spec)
+    assert tool["function"]["name"] == "light.turn_on"
+    assert "brightness_pct" in tool["function"]["parameters"]["properties"]
+    assert "entity_id" in tool["function"]["parameters"]["required"]
+
+
+@pytest.mark.asyncio
+async def test_service_catalog_ttl(monkeypatch):
+    os.environ.update({"HA_URL": "http://ha", "HA_TOKEN": "tok"})
+    calls = []
+
+    async def handler(request):
+        calls.append(1)
+        return httpx.Response(200, json=[{"domain": "light", "services": {}}])
+
+    transport = httpx.MockTransport(handler)
+
+    class FakeHTTPX:
+        def __init__(self, real):
+            self._real = real
+            self.Response = real.Response
+
+        def AsyncClient(self, **kw):
+            kw["transport"] = transport
+            return self._real.AsyncClient(**kw)
+
+    import app.services.service_catalog as sc
+
+    monkeypatch.setattr(sc, "httpx", FakeHTTPX(httpx))
+
+    cat = ServiceCatalog(ttl=10)
+    await cat.get_domain_services("light")
+    await cat.get_domain_services("light")
+    assert len(calls) == 1
+    cat._ts -= 11
+    await cat.get_domain_services("light")
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- add async `ServiceCatalog` with TTL caching
- generate function tools from the service catalog
- integrate catalog into `/process-request`
- update `.env.sample` and README
- add unit tests for catalog and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa1e47e4c83278268e21fcffea020