### PR TITLE
Add interactive demo CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ Add the connection details to your `.env` file (see `.env.sample`) and run `dock
 ### Service cache
 The catalog of `/api/services` is fetched on first request and cached for 6 h
 (configurable via `SERVICE_CACHE_TTL`).
+
+### Quick demo
+poetry run python demo.py "Hány fok van a nappaliban?"

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,101 @@
+import argparse
+import asyncio
+import json
+import os
+from typing import List, Dict
+
+import httpx
+try:
+    from colorama import Fore, Style
+    _COLOR = True
+except Exception:
+    class Dummy:
+        RESET = ''
+    Fore = Style = Dummy()
+    _COLOR = False
+
+API_URL = os.getenv("DEMO_API_URL", "http://localhost:8000")
+
+
+def _color(text: str, color: str) -> str:
+    if _COLOR:
+        return f"{color}{text}{Style.RESET_ALL}"
+    return text
+
+
+def _parse_first_entity(system_prompt: str) -> str | None:
+    for line in system_prompt.splitlines():
+        if line.lower().startswith("relevant entities:"):
+            parts = line.split(":", 1)[1].strip().split(",")
+            return parts[0].strip() if parts else None
+    return None
+
+
+def stub_llm(messages: List[Dict], tools: List[Dict]) -> Dict:
+    """Return a dummy LLM response."""
+    reply_content = messages[-1]["content"]
+    if not tools:
+        return {"role": "assistant", "content": reply_content}
+
+    tool = tools[0]
+    func = tool["function"]
+    args: Dict[str, str] = {}
+    params = func.get("parameters", {}).get("properties", {})
+    if params:
+        first_param = next(iter(params))
+        if first_param == "entity_id":
+            ent = _parse_first_entity(messages[0]["content"])
+            if ent:
+                args[first_param] = ent
+    tool_calls = [
+        {
+            "id": "c1",
+            "type": "function",
+            "function": {
+                "name": func["name"],
+                "arguments": json.dumps(args),
+            },
+        }
+    ]
+    return {"role": "assistant", "content": reply_content, "tool_calls": tool_calls}
+
+
+async def run_demo(question: str, llm: str = "stub") -> str:
+    print(_color(f"> USER: {question}", Fore.GREEN))
+    async with httpx.AsyncClient(base_url=API_URL, timeout=10.0) as client:
+        r1 = await client.post("/process-request", json={"user_message": question})
+    print(_color(f"\u2192 /process-request: {r1.status_code} {r1.reason_phrase}", Fore.CYAN))
+    data = r1.json()
+    messages = data.get("messages", [])
+    tools = data.get("tools", [])
+
+    if llm == "stub":
+        assistant = stub_llm(messages, tools)
+        if assistant.get("tool_calls"):
+            tc = assistant["tool_calls"][0]
+            print(_color(
+                f"\u2192 Stub-LLM: calling {tc['function']['name']}({tc['function']['arguments']})",
+                Fore.MAGENTA,
+            ))
+    else:
+        assistant = {"role": "assistant", "content": messages[-1]["content"], "tool_calls": None}
+
+    payload = {"id": "1", "choices": [{"message": assistant}]}
+    async with httpx.AsyncClient(base_url=API_URL, timeout=10.0) as client:
+        r2 = await client.post("/process-response", json=payload)
+    print(_color(f"\u2192 /process-response: {r2.status_code} {r2.reason_phrase}", Fore.CYAN))
+    result = r2.json()
+    print(_color(f"< ASSISTANT: {result.get('message')}", Fore.YELLOW))
+    return result.get("message", "")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("question", nargs=1, help="User question")
+    parser.add_argument("--llm", choices=["stub", "openai", "gemini"], default="stub")
+    args = parser.parse_args()
+    asyncio.run(run_demo(args.question[0], args.llm))
+
+
+if __name__ == "__main__":
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -2184,4 +2184,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "3e2b8a1f723a23d8f314613d0b33cdd3b99d56a375fd5859737bbb464194f747"
+content-hash = "df92c9d9a808761cd3b26b5629f0c7e0573254487837982dc9ae0d709413240d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ sentence-transformers = "^2.2"
 websockets = "^12.0"
 influxdb-client = "^1.40"
 cachetools = "^5.3"
+colorama = "^0.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1"

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,67 @@
+import sys
+import json
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+
+import demo
+
+
+@pytest.mark.asyncio
+async def test_demo_success(monkeypatch, capsys):
+    resp_request = {
+        "messages": [
+            {"role": "system", "content": "Relevant entities: light.test"},
+            {"role": "user", "content": "Turn on"},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "light.turn_on",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"entity_id": {"type": "string", "required": True}},
+                        "required": ["entity_id"],
+                    },
+                },
+            }
+        ],
+    }
+
+    async def handler(request):
+        if request.url.path == "/process-request":
+            return httpx.Response(200, json=resp_request)
+        assert request.url.path == "/process-response"
+        payload = json.loads(request.content.decode())
+        tc = payload["choices"][0]["message"]["tool_calls"][0]
+        assert tc["function"]["name"] == "light.turn_on"
+        return httpx.Response(200, json={"status": "ok", "message": "OK"})
+
+    transport = httpx.MockTransport(handler)
+
+    class FakeHTTPX:
+        def __init__(self, real):
+            self._real = real
+            self.Response = real.Response
+
+        def AsyncClient(self, **kw):
+            kw["transport"] = transport
+            return self._real.AsyncClient(**kw)
+
+    monkeypatch.setattr(demo, "httpx", FakeHTTPX(httpx))
+
+    msg = await demo.run_demo("Turn on")
+    assert msg == "OK"
+    out = capsys.readouterr().out
+    assert "/process-request" in out
+    assert "/process-response" in out
+
+
+def test_demo_argparse():
+    proc = subprocess.run([sys.executable, str(Path(__file__).resolve().parents[1] / "demo.py")], capture_output=True)
+    assert proc.returncode == 2
+    assert b"usage" in proc.stderr.lower()
+


### PR DESCRIPTION
## Summary
- implement CLI demo for full request-response cycle
- add optional color output via colorama dependency
- document demo usage in README
- include tests for demo script

## Testing
- `poetry run pytest -k demo -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa8efb4d88327b397162fe264a285