### PR TITLE
Add Dockerfile for portainer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+.env
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# 🐍 Alap Python slim image
+FROM python:3.11-slim
+
+# 📝 Munkakönyvtár
+WORKDIR /app
+
+# 🔧 Poetry telepítés + dependenciák
+COPY pyproject.toml poetry.lock ./
+RUN pip install poetry && poetry config virtualenvs.create false && poetry install --no-root
+
+# 📄 Kód bemásolása
+COPY . .
+
+# 🚀 Indítás
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ Run the demo locally (requires HA token and running services):
 ```bash
 poetry run python demo.py "Kapcsold fel a nappali lámpát"
 ```
+
+## Docker
+
+```
+# Lokális build tesztelése:
+docker build -t ha-rag-bridge .
+docker run -p 8000:8000 ha-rag-bridge
+```


### PR DESCRIPTION
## Summary
- create Dockerfile to run the FastAPI service in Docker
- ignore virtualenv and cache files with `.dockerignore`
- document how to build and run the container locally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbd5df8488327a2ce9e4b4862667d