### PR TITLE
Add bootstrap CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
         ports:
           - 8529:8529
         options: >-
-          --health-cmd="curl -f -u root:pass http://localhost:8529/_api/version || exit 1"
+          --health-cmd="arangosh --server.endpoint tcp://localhost:8529 \
+          --server.username root --server.password pass \
+          --javascript.execute-string '1'"
           --health-interval=10s --health-timeout=5s --health-retries=5
         env:
           ARANGO_ROOT_PASSWORD: pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         ports:
           - 8529:8529
         options: >-
-          --name arangodb \
+          --name arangodb
           --health-cmd="arangosh --server.endpoint tcp://localhost:8529 \
           --server.username root --server.password pass \
           --javascript.execute-string '1'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - run: poetry install
       - run: poetry run pytest
       - run: docker build -t ha-rag-bridge .
-      - run: docker exec arangodb arangosh --server.endpoint tcp://localhost:8529 --server.username root --server.password pass --javascript.execute 'db._create("embeddings")'
+      - run: docker exec arangodb arangosh --server.endpoint tcp://localhost:8529 --server.username root --server.password pass --javascript.execute-string 'db._create("embeddings")'
       - run: docker run --network host -e ARANGO_URL=http://localhost:8529 -e ARANGO_USER=root -e ARANGO_PASS=pass ha-rag-bridge ha-rag-bootstrap --reindex embeddings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
           --server.username root --server.password pass \
           --javascript.execute-string '1'"
           --health-interval=10s --health-timeout=5s --health-retries=5
-          --experimental-vector-index
         env:
           ARANGO_ROOT_PASSWORD: pass
+        command: --experimental-vector-index
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         ports:
           - 8529:8529
         options: >-
-          --health-cmd="curl -f http://localhost:8529/_api/version || exit 1"
+          --health-cmd="curl -f -u root:pass http://localhost:8529/_api/version || exit 1"
           --health-interval=10s --health-timeout=5s --health-retries=5
         env:
           ARANGO_ROOT_PASSWORD: pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         ports:
           - 8529:8529
         options: >-
+          --name arangodb \
           --health-cmd="arangosh --server.endpoint tcp://localhost:8529 \
           --server.username root --server.password pass \
           --javascript.execute-string '1'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,5 @@ jobs:
       - run: poetry install
       - run: poetry run pytest
       - run: docker build -t ha-rag-bridge .
+      - run: docker exec arangodb arangosh --server.endpoint tcp://localhost:8529 --server.username root --server.password pass --javascript.execute 'db._create("embeddings")'
       - run: docker run --network host -e ARANGO_URL=http://localhost:8529 -e ARANGO_USER=root -e ARANGO_PASS=pass ha-rag-bridge ha-rag-bootstrap --reindex embeddings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           --server.username root --server.password pass \
           --javascript.execute-string '1'"
           --health-interval=10s --health-timeout=5s --health-retries=5
+          --experimental-vector-index
         env:
           ARANGO_ROOT_PASSWORD: pass
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      arangodb:
+        image: arangodb/arangodb:latest
+        ports:
+          - 8529:8529
+        options: >-
+          --health-cmd="curl -f http://localhost:8529/_api/version || exit 1"
+          --health-interval=10s --health-timeout=5s --health-retries=5
+        env:
+          ARANGO_ROOT_PASSWORD: pass
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -17,3 +27,5 @@ jobs:
           virtualenvs-create: false
       - run: poetry install
       - run: poetry run pytest
+      - run: docker build -t ha-rag-bridge .
+      - run: docker run --network host -e ARANGO_URL=http://localhost:8529 -e ARANGO_USER=root -e ARANGO_PASS=pass ha-rag-bridge ha-rag-bootstrap --reindex embeddings

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN poetry install --no-root
 
 # 📄 Copy application code
 COPY . .
+# install package so CLI is available
+RUN poetry install --only-root
 
 # 🚀 Run the FastAPI application with Uvicorn
 CMD ["/bin/sh", "-c", "ha-rag-bootstrap && uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config docker/uvicorn_log.ini"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN poetry install --no-root
 COPY . .
 
 # 🚀 Run the FastAPI application with Uvicorn
-CMD ["/bin/sh", "-c", "python -m ha_rag_bridge.bootstrap && uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config docker/uvicorn_log.ini"]
+CMD ["/bin/sh", "-c", "ha-rag-bootstrap && uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config docker/uvicorn_log.ini"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ git clone <repo>
 cp .env.sample .env
 docker compose up -d
 ```
-The container automatically bootstraps the database on start.
+The container automatically bootstraps the database on start. Make sure your
+ArangoDB instance runs with the `--experimental-vector-index` flag enabled so
+vector search works correctly.
 
 ## Bootstrap CLI
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ docker compose up -d
 ```
 The container automatically bootstraps the database on start.
 
+## Bootstrap CLI
+
+After installing via Poetry or pulling the Docker image you can run the
+bootstrap process directly:
+
+```bash
+docker run --rm ghcr.io/…/ha-rag-bridge:latest ha-rag-bootstrap --dry-run
+```
+
+Flags:
+
+- `--dry-run` – only analyse and do not modify the database
+- `--force` – drop and recreate indexes on dimension mismatch
+- `--reindex [collection]` – rebuild vector indexes (all when omitted)
+- `--quiet` – suppress info messages
+
 ## Embedding Provider
 
 Set `EMBEDDING_PROVIDER` to choose how text embeddings are created. Valid values:

--- a/app/main.py
+++ b/app/main.py
@@ -64,7 +64,7 @@ try:
         (
             i
             for i in col.indexes()
-            if i["type"] == "hnsw" and i["fields"][0] == "embedding"
+            if i["type"] == "vector" and i["fields"][0] == "embedding"
         ),
         None,
     )

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -51,7 +51,7 @@ async def reindex(request: Request) -> dict:
     start = perf_counter()
     for name in collections:
         col = db.collection(name)
-        idx = next((i for i in col.indexes() if i["type"] == "hnsw"), None)
+        idx = next((i for i in col.indexes() if i["type"] == "vector"), None)
         if idx and (force or idx.get("dimensions") != embed_dim):
             col.delete_index(idx["id"])
             logger.warning(
@@ -60,7 +60,7 @@ async def reindex(request: Request) -> dict:
             dropped += 1
             idx = None
         if not idx:
-            col.add_index({"type": "hnsw", "fields": ["embedding"], "dimensions": embed_dim, "metric": "cosine"})
+            col.add_index({"type": "vector", "fields": ["embedding"], "dimensions": embed_dim, "metric": "cosine"})
             created += 1
     took_ms = int((perf_counter() - start) * 1000)
     logger.info(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,5 @@ services:
       - ADMIN_TOKEN=${ADMIN_TOKEN}
       - AUTO_BOOTSTRAP=1
     command: >
-      sh -c '
-        python -m ha_rag_bridge.bootstrap || exit 1
-        exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config docker/uvicorn_log.ini
-      '
+      ha-rag-bootstrap &&
+      uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config docker/uvicorn_log.ini

--- a/ha_rag_bridge/bootstrap/__init__.py
+++ b/ha_rag_bridge/bootstrap/__init__.py
@@ -101,7 +101,7 @@ def _bootstrap_impl(*, force: bool = False) -> None:
         entity.delete_index(idx["id"])
         idx = None
     if not idx:
-        entity.add_index({
+        entity._add_index({
             "type": "hnsw",
             "fields": ["embedding"],
             "dimensions": embed_dim,

--- a/ha_rag_bridge/bootstrap/__init__.py
+++ b/ha_rag_bridge/bootstrap/__init__.py
@@ -94,7 +94,7 @@ def _bootstrap_impl(*, force: bool = False) -> None:
 
     entity = db.collection("entity")
     idx = next(
-        (i for i in entity.indexes() if i["type"] == "hnsw" and i["fields"] == ["embedding"]),
+        (i for i in entity.indexes() if i["type"] == "vector" and i["fields"] == ["embedding"]),
         None,
     )
     if idx and idx.get("dimensions") != embed_dim:
@@ -102,7 +102,7 @@ def _bootstrap_impl(*, force: bool = False) -> None:
         idx = None
     if not idx:
         entity._add_index({
-            "type": "hnsw",
+            "type": "vector",
             "fields": ["embedding"],
             "dimensions": embed_dim,
             "metric": "cosine",

--- a/ha_rag_bridge/bootstrap/__main__.py
+++ b/ha_rag_bridge/bootstrap/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/ha_rag_bridge/bootstrap/cli.py
+++ b/ha_rag_bridge/bootstrap/cli.py
@@ -39,7 +39,7 @@ def _reindex(collection: str | None, *, force: bool = False, dry_run: bool = Fal
     dropped = created = 0
     for name in collections:
         col = db.collection(name)
-        idx = next((i for i in col.indexes() if i["type"] == "hnsw"), None)
+        idx = next((i for i in col.indexes() if i["type"] == "vector"), None)
         if idx and (force or idx.get("dimensions") != embed_dim):
             if not dry_run:
                 col.delete_index(idx["id"])
@@ -49,7 +49,7 @@ def _reindex(collection: str | None, *, force: bool = False, dry_run: bool = Fal
         if not idx:
             if not dry_run:
                 col._add_index({
-                    "type": "hnsw",
+                    "type": "vector",
                     "fields": ["embedding"],
                     "dimensions": embed_dim,
                     "metric": "cosine",

--- a/ha_rag_bridge/bootstrap/cli.py
+++ b/ha_rag_bridge/bootstrap/cli.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import os
+from time import perf_counter
+
+from colorama import Fore, Style, init
+
+from . import run as bootstrap_run
+
+
+def _reindex(collection: str | None, *, force: bool = False, dry_run: bool = False) -> int:
+    """Rebuild vector index for given collection or all."""
+    from arango import ArangoClient
+    from ha_rag_bridge.logging import get_logger
+
+    logger = get_logger(__name__)
+    try:
+        arango = ArangoClient(hosts=os.environ["ARANGO_URL"])
+        db = arango.db(
+            os.getenv("ARANGO_DB", "_system"),
+            username=os.environ["ARANGO_USER"],
+            password=os.environ["ARANGO_PASS"],
+        )
+    except KeyError as exc:
+        logger.error("missing config", missing=str(exc))
+        return 2
+
+    collections = []
+    if collection:
+        if not db.has_collection(collection):
+            logger.error("collection not found", collection=collection)
+            return 2
+        collections = [collection]
+    else:
+        collections = [c["name"] for c in db.collections() if not c["name"].startswith("_")]
+
+    embed_dim = int(os.getenv("EMBED_DIM", "1536"))
+    dropped = created = 0
+    for name in collections:
+        col = db.collection(name)
+        idx = next((i for i in col.indexes() if i["type"] == "hnsw"), None)
+        if idx and (force or idx.get("dimensions") != embed_dim):
+            if not dry_run:
+                col.delete_index(idx["id"])
+            logger.warning("vector index recreated", collection=name, force=force)
+            dropped += 1
+            idx = None
+        if not idx:
+            if not dry_run:
+                col.add_index({
+                    "type": "hnsw",
+                    "fields": ["embedding"],
+                    "dimensions": embed_dim,
+                    "metric": "cosine",
+                })
+            created += 1
+    logger.info(
+        "reindex finished",
+        collection=collection or "all",
+        dropped=dropped,
+        created=created,
+        dimensions=embed_dim,
+    )
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="ha-rag-bootstrap")
+    parser.add_argument("--dry-run", action="store_true", help="plan only, no changes")
+    parser.add_argument("--force", action="store_true", help="drop+recreate on dim mismatch")
+    parser.add_argument("--reindex", nargs="?", const="all", metavar="collection", help="rebuild HNSW index")
+    parser.add_argument("--quiet", action="store_true", help="only WARN and ERROR logs")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    init()
+
+    if args.quiet:
+        os.environ["LOG_LEVEL"] = "WARNING"
+
+    start = perf_counter()
+    if args.reindex is not None:
+        collection = None if args.reindex == "all" else args.reindex
+        code = _reindex(collection, force=args.force, dry_run=args.dry_run)
+    else:
+        code = bootstrap_run(None, dry_run=args.dry_run, force=args.force)
+    took = int((perf_counter() - start) * 1000)
+    dim = int(os.getenv("EMBED_DIM", "1536"))
+
+    icon = f"{Fore.GREEN}✓{Style.RESET_ALL}" if code == 0 else f"{Fore.RED}✗{Style.RESET_ALL}"
+    print(f"{icon} {dim}d {took}ms")
+    raise SystemExit(code)
+

--- a/ha_rag_bridge/bootstrap/cli.py
+++ b/ha_rag_bridge/bootstrap/cli.py
@@ -48,7 +48,7 @@ def _reindex(collection: str | None, *, force: bool = False, dry_run: bool = Fal
             idx = None
         if not idx:
             if not dry_run:
-                col.add_index({
+                col._add_index({
                     "type": "hnsw",
                     "fields": ["embedding"],
                     "dimensions": embed_dim,

--- a/migrations/001_init_collections.arangodb
+++ b/migrations/001_init_collections.arangodb
@@ -30,8 +30,8 @@ const entity = db._collection('entity');
 if (!entity.getIndexes().some(i => i.type === 'hash' && i.fields[0] === 'entity_id')) {
   entity.ensureIndex({ type: 'hash', fields: ['entity_id'], unique: true });
 }
-if (!entity.getIndexes().some(i => i.type === 'hnsw' && i.fields[0] === 'embedding')) {
-  entity.ensureIndex({ type: 'hnsw', fields: ['embedding'], dimensions: DIM, metric: 'cosine' });
+if (!entity.getIndexes().some(i => i.type === 'vector' && i.fields[0] === 'embedding')) {
+  entity.ensureIndex({ type: 'vector', fields: ['embedding'], dimensions: DIM, metric: 'cosine' });
 }
 
 const edge = db._collection('edge');

--- a/migrations/002_manual_collection.arangodb
+++ b/migrations/002_manual_collection.arangodb
@@ -10,8 +10,8 @@ function ensureDocumentCollection(name) {
 }
 
 const manual = ensureDocumentCollection('document');
-if (!manual.getIndexes().some(i => i.type === 'hnsw')) {
-  manual.ensureIndex({type:'hnsw', fields:['embedding'], dimensions:DIM, metric:'cosine'});
+if (!manual.getIndexes().some(i => i.type === 'vector')) {
+  manual.ensureIndex({type:'vector', fields:['embedding'], dimensions:DIM, metric:'cosine'});
 }
 
 const viewProps = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["lopeti <lovas.peter.hu@gmail.com>"]
 packages = [
     { include = "app" }
     ,{ include = "scripts" }
+    ,{ include = "ha_rag_bridge" }
 ]
 
 [tool.poetry.dependencies]
@@ -22,6 +23,9 @@ cachetools = "^5.3"
 colorama = "^0.4"
 "pdfminer.six" = "^20221105"
 structlog = "^24"
+
+[tool.poetry.scripts]
+ha-rag-bootstrap = "ha_rag_bridge.bootstrap.cli:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -34,3 +34,17 @@ def test_bootstrap_idempotent(monkeypatch):
     meta_col.get.return_value = {'value': boot.SCHEMA_LATEST}
     boot.bootstrap()
     assert meta_col.insert.call_count == 2
+
+
+def test_run_dry_run(monkeypatch):
+    setup_env()
+    called = False
+
+    def fake_impl(*a, **k):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(boot, "_bootstrap_impl", fake_impl)
+    code = boot.run(None, dry_run=True)
+    assert code == 0
+    assert not called

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+
+from ha_rag_bridge.bootstrap import cli
+
+@pytest.mark.parametrize(
+    "argv,exp",
+    [
+        (["--dry-run"], {"dry_run": True, "force": False, "reindex": None}),
+        (["--force", "--reindex", "embeddings"], {"dry_run": False, "force": True, "reindex": "embeddings"}),
+    ],
+)
+def test_cli_parsing(monkeypatch, argv, exp):
+    called = {}
+
+    def fake_run(plan, *, dry_run=False, force=False):
+        called["run"] = {"dry_run": dry_run, "force": force}
+        return 0
+
+    def fake_reindex(collection=None, *, force=False, dry_run=False):
+        called["reindex"] = {"collection": collection, "force": force, "dry_run": dry_run}
+        return 0
+
+    monkeypatch.setattr(cli, "bootstrap_run", fake_run)
+    monkeypatch.setattr(cli, "_reindex", fake_reindex)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(argv)
+    assert exc.value.code == 0
+    if exp["reindex"] is None:
+        assert called["run"] == {"dry_run": exp["dry_run"], "force": exp["force"]}
+    else:
+        assert called["reindex"] == {"collection": exp["reindex"], "force": exp["force"], "dry_run": exp["dry_run"]}
+
+
+def test_cli_quiet(monkeypatch):
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.setattr(cli, "bootstrap_run", lambda *a, **k: 0)
+    with pytest.raises(SystemExit):
+        cli.main(["--quiet"])
+    assert os.environ["LOG_LEVEL"] == "WARNING"


### PR DESCRIPTION
## Summary
- implement argparse CLI with color output
- expose CLI via `__main__` and poetry script
- refactor bootstrap module to use `run()` API
- simplify Docker entrypoints
- document new `ha-rag-bootstrap` command
- add unit tests and CI e2e check

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2361da9c8327be05ac9811ab8852