### PR TITLE
Fix collection naming rules and add migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 
 - Added validation of collection names during bootstrap.
 - New CLI flags `--skip-invalid` and `--rename-invalid` to handle illegal names.
+- Breaking change: `_meta` collection renamed to `meta` and auto-migrated.
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,21 @@ Flags:
 - `--skip-invalid` – skip collections with illegal names
 - `--rename-invalid` – attempt to auto-fix illegal names
 
+Breaking change in v12.4: the internal collection `_meta` was renamed to `meta`.
+Existing installations are migrated automatically during bootstrap.
+
 ### Collection naming rules & auto-fix flags
 
 Collection names must start with a letter and may contain letters, digits,
 hyphen or underscore up to 255 characters. Names beginning with `arango` are
 reserved. When the bootstrap encounters an invalid name you can either skip it
 with `--skip-invalid` or automatically rename it using:
+
+| Rule | Example |
+|------|--------|
+| Must not start with `_` | `_foo` → invalid |
+| Allowed characters | `a-z`, `A-Z`, `0-9`, `-`, `_` |
+| Reserved prefix | `arango*` |
 
 ```bash
 ha-rag-bootstrap --rename-invalid

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -90,8 +90,8 @@ async def status_endpoint(request: Request) -> dict:
         password=os.environ["ARANGO_PASS"],
     )
     version = SCHEMA_LATEST
-    if db.has_collection("_meta"):
-        doc = db.collection("_meta").get("schema_version")
+    if db.has_collection("meta"):
+        doc = db.collection("meta").get("schema_version")
         if doc:
             version = int(doc.get("value", 0))
     return {

--- a/ha_rag_bridge/bootstrap/naming.py
+++ b/ha_rag_bridge/bootstrap/naming.py
@@ -1,11 +1,20 @@
 import re
 from typing import Iterable
 
+RESERVED_PREFIXES = {"_"}
+INVALID_CHARS = r"[^a-zA-Z0-9_-]"
+
 VALID_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{0,254}$")
 
 
 def is_valid(name: str) -> bool:
     """Return True if collection name is valid."""
+    if not name:
+        return False
+    if name[0] in RESERVED_PREFIXES:
+        return False
+    if re.search(INVALID_CHARS, name):
+        return False
     return bool(VALID_RE.match(name)) and not name.lower().startswith("arango")
 
 
@@ -56,3 +65,8 @@ def safe_create_collection(db, name: str, *, edge: bool = False, force: bool = F
     except Exception as exc:
         logger.error("create collection failed", name=name, edge=edge, error=str(exc))
         raise
+
+
+def safe_rename(col, new_name: str) -> None:
+    if col.name != new_name and not col.database.has_collection(new_name):
+        col.rename(new_name)

--- a/ha_rag_bridge/bootstrap/plan.py
+++ b/ha_rag_bridge/bootstrap/plan.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class Step:
+    name: str
+    edge: bool = False
+
+
+PLAN = [
+    Step(name="meta"),
+    Step(name="bootstrap_log"),
+    Step(name="events_old"),
+    Step(name="edge_tmp", edge=True),
+]

--- a/ha_rag_bridge/bootstrap/plan_validator.py
+++ b/ha_rag_bridge/bootstrap/plan_validator.py
@@ -1,0 +1,7 @@
+from .naming import is_valid
+
+
+def validate_plan(plan):
+    bad = [step.name for step in plan if not is_valid(step.name)]
+    if bad:
+        raise ValueError(f"illegal collection names in plan: {bad}")

--- a/migrations/02__meta_collection.py
+++ b/migrations/02__meta_collection.py
@@ -2,5 +2,5 @@ from ha_rag_bridge.bootstrap.naming import safe_create_collection
 
 
 def run(db):
-    if not db.has_collection("_meta"):
-        safe_create_collection(db, "_meta")
+    if not db.has_collection("meta"):
+        safe_create_collection(db, "meta")

--- a/migrations/03__rename_meta.py
+++ b/migrations/03__rename_meta.py
@@ -1,0 +1,8 @@
+from ha_rag_bridge.bootstrap.naming import safe_rename
+
+
+def run(db):
+    if db._collection("_meta"):
+        safe_rename(db._collection("_meta"), "meta")
+    if db._collection("_bootstrap_log"):
+        safe_rename(db._collection("_bootstrap_log"), "bootstrap_log")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -16,7 +16,7 @@ def test_bootstrap_idempotent(monkeypatch):
     meta_col = MagicMock()
     meta_col.get.return_value = None
     db = MagicMock()
-    db.has_collection.side_effect = lambda name: name == '_meta'
+    db.has_collection.side_effect = lambda name: name == 'meta'
     db.collection.return_value = meta_col
     db.collections.return_value = []
     db.has_view.return_value = True

--- a/tests/test_invalid_names.py
+++ b/tests/test_invalid_names.py
@@ -1,0 +1,51 @@
+import os
+from unittest.mock import MagicMock
+import pytest
+
+from ha_rag_bridge.bootstrap import cli, naming
+from ha_rag_bridge.bootstrap.plan_validator import validate_plan
+from ha_rag_bridge.bootstrap.plan import Step
+import ha_rag_bridge.bootstrap as boot
+
+
+def test_plan_validate():
+    plan = [Step(name="_bad")]
+    with pytest.raises(ValueError):
+        validate_plan(plan)
+
+
+def setup_env():
+    os.environ["ARANGO_URL"] = "http://db"
+    os.environ["ARANGO_USER"] = "root"
+    os.environ["ARANGO_PASS"] = "pass"
+    os.environ["AUTO_BOOTSTRAP"] = "1"
+
+
+def test_rename_invalid_suffix(monkeypatch):
+    setup_env()
+    created = []
+
+    def fake_create(db, name, *, edge=False, force=False):
+        created.append(name)
+        return MagicMock()
+
+    monkeypatch.setattr(boot.naming, "safe_create_collection", fake_create)
+
+    def fake_impl(*, force=False, skip_invalid=False, rename_invalid=False):
+        existing = {"bad"}
+        name = "_bad"
+        if not naming.is_valid(name):
+            if rename_invalid:
+                name = naming.to_valid_name(name, existing)
+                fake_create(None, name)
+            elif skip_invalid:
+                return
+            else:
+                raise ValueError(f"illegal collection name '{name}'")
+
+    monkeypatch.setattr(boot, "_bootstrap_impl", fake_impl)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--rename-invalid"])
+    assert exc.value.code == 0
+    assert created == ["bad__1"]


### PR DESCRIPTION
## Summary
- enforce new collection naming restrictions
- add safe_rename helper and plan validation
- rename `_meta` to `meta` and migrate old installs
- update bootstrap code and tests
- document new naming rules

## Testing
- `pytest tests/test_invalid_names.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ddcf8b0a88327aad92f993d16cb98