### PR TITLE
Implement BridgeDB adapter and meta bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 - Added validation of collection names during bootstrap.
 - New CLI flags `--skip-invalid` and `--rename-invalid` to handle illegal names.
 - Breaking change: `_meta` collection renamed to `meta` and auto-migrated.
+- Breaking internal: JS-API calls replaced with Python client; no arangosh binary needed in v12.5.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Flags:
 
 Breaking change in v12.4: the internal collection `_meta` was renamed to `meta`.
 Existing installations are migrated automatically during bootstrap.
+Breaking internal: JS-API calls were replaced with Python client usage. Upgrading to v12.5 no longer requires the `arangosh` binary.
+
+```python
+from ha_rag_bridge.db import BridgeDB
+db = BridgeDB(...)
+db.ensure_col("events")
+```
 
 ### Collection naming rules & auto-fix flags
 

--- a/ha_rag_bridge/bootstrap/__init__.py
+++ b/ha_rag_bridge/bootstrap/__init__.py
@@ -78,8 +78,8 @@ def _bootstrap_impl(*, force: bool = False, skip_invalid: bool = False, rename_i
     meta_col = db.ensure_col("meta")
     doc = meta_col.get("schema_version")
     if doc is None:
-        meta_col.insert({"_key": "schema_version", "value": SCHEMA_LATEST})
-        version = SCHEMA_LATEST
+        meta_col.insert({"_key": "schema_version", "value": 0})
+        version = 0
     else:
         version = int(doc.get("value", 0))
 

--- a/ha_rag_bridge/bootstrap/__init__.py
+++ b/ha_rag_bridge/bootstrap/__init__.py
@@ -3,6 +3,7 @@ import glob
 import importlib.util
 from time import perf_counter
 from arango import ArangoClient
+from ha_rag_bridge.db import BridgeDB
 
 from .naming import safe_create_collection, is_valid, to_valid_name
 
@@ -71,16 +72,16 @@ def _bootstrap_impl(*, force: bool = False, skip_invalid: bool = False, rename_i
         sys_db.create_database(db_name)
 
     db = client.db(db_name, username=user, password=password)
+    db.__class__ = BridgeDB
 
     # Run pending migrations based on stored schema version
-    version = 0
-    if db.has_collection("meta"):
-        meta_col = db.collection("meta")
-        doc = meta_col.get("schema_version")
-        if doc:
-            version = int(doc.get("value", 0))
+    meta_col = db.ensure_col("meta")
+    doc = meta_col.get("schema_version")
+    if doc is None:
+        meta_col.insert({"_key": "schema_version", "value": SCHEMA_LATEST})
+        version = SCHEMA_LATEST
     else:
-        meta_col = safe_create_collection(db, "meta")
+        version = int(doc.get("value", 0))
 
     if version < SCHEMA_LATEST:
         for num in range(version + 1, SCHEMA_LATEST + 1):
@@ -131,7 +132,7 @@ def _bootstrap_impl(*, force: bool = False, skip_invalid: bool = False, rename_i
         entity.delete_index(idx["id"])
         idx = None
     if not idx:
-        entity._add_index({
+        entity.add_index({
             "type": "vector",
             "fields": ["embedding"],
             "dimensions": embed_dim,

--- a/ha_rag_bridge/bootstrap/cli.py
+++ b/ha_rag_bridge/bootstrap/cli.py
@@ -48,7 +48,7 @@ def _reindex(collection: str | None, *, force: bool = False, dry_run: bool = Fal
             idx = None
         if not idx:
             if not dry_run:
-                col._add_index({
+                col.add_index({
                     "type": "vector",
                     "fields": ["embedding"],
                     "dimensions": embed_dim,

--- a/ha_rag_bridge/db/__init__.py
+++ b/ha_rag_bridge/db/__init__.py
@@ -5,8 +5,20 @@ from ha_rag_bridge.logging import get_logger
 
 
 class BridgeDB(StandardDatabase):
-    """Thin wrapper adding helpers compatible with arangosh prose."""
+    """
+    A thin wrapper around StandardDatabase that provides utility methods for 
+    working with collections in a simplified manner.
 
+    This class adds helper methods to streamline common operations, such as 
+    retrieving or ensuring the existence of collections. These methods are 
+    designed to be compatible with workflows inspired by ArangoDB's arangosh 
+    (ArangoDB shell) but are adapted for Python usage.
+
+    Helper methods:
+        - get_col(name): Returns a collection handle if it exists, otherwise None.
+        - ensure_col(name, edge=False): Ensures a collection exists, creating it 
+          if necessary. Supports both document and edge collections.
+    """
     def get_col(self, name: str):
         """Return collection handle if exists else None."""
         return self.collection(name) if self.has_collection(name) else None

--- a/ha_rag_bridge/db/__init__.py
+++ b/ha_rag_bridge/db/__init__.py
@@ -1,0 +1,28 @@
+from arango.database import StandardDatabase
+from arango.exceptions import ArangoServerError
+
+from ha_rag_bridge.logging import get_logger
+
+
+class BridgeDB(StandardDatabase):
+    """Thin wrapper adding helpers compatible with arangosh prose."""
+
+    def get_col(self, name: str):
+        """Return collection handle if exists else None."""
+        return self.collection(name) if self.has_collection(name) else None
+
+    def ensure_col(self, name: str, *, edge: bool = False):
+        try:
+            if self.has_collection(name):
+                return self.collection(name)
+            return self.create_collection(name, edge=edge)
+        except ArangoServerError as exc:  # pragma: no cover - connection errors
+            logger = get_logger(__name__)
+            logger.error(
+                "create collection failed",
+                error_code=exc.error_code,
+                error_message=exc.error_message,
+            )
+            raise SystemExit(4)
+        except ValueError as exc:  # invalid name
+            raise SystemExit(2) from exc

--- a/migrations/03__rename_meta.py
+++ b/migrations/03__rename_meta.py
@@ -2,7 +2,9 @@ from ha_rag_bridge.bootstrap.naming import safe_rename
 
 
 def run(db):
-    if db._collection("_meta"):
-        safe_rename(db._collection("_meta"), "meta")
-    if db._collection("_bootstrap_log"):
-        safe_rename(db._collection("_bootstrap_log"), "bootstrap_log")
+    col = db.get_col("_meta")
+    if col:
+        safe_rename(col, "meta")
+    col = db.get_col("_bootstrap_log")
+    if col:
+        safe_rename(col, "bootstrap_log")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -16,11 +16,9 @@ def test_bootstrap_idempotent(monkeypatch):
     meta_col = MagicMock()
     meta_col.get.return_value = None
     db = MagicMock()
-    db.has_collection.side_effect = lambda name: name == 'meta'
-    db.collection.return_value = meta_col
+    db.ensure_col.return_value = meta_col
     db.collections.return_value = []
     db.has_view.return_value = True
-    meta_col.get.return_value = None
     sys_db = MagicMock()
     sys_db.has_database.return_value = True
     client = MagicMock()
@@ -33,7 +31,7 @@ def test_bootstrap_idempotent(monkeypatch):
     assert meta_col.insert.called
     meta_col.get.return_value = {'value': boot.SCHEMA_LATEST}
     boot.bootstrap()
-    assert meta_col.insert.call_count == 2
+    assert meta_col.insert.call_count == 3
 
 
 def test_run_dry_run(monkeypatch):

--- a/tests/test_dbadapter.py
+++ b/tests/test_dbadapter.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+from ha_rag_bridge.db import BridgeDB
+
+
+def test_ensure_col(monkeypatch):
+    db = BridgeDB.__new__(BridgeDB)
+    db.has_collection = MagicMock(return_value=False)
+    created_col = MagicMock()
+    db.create_collection = MagicMock(return_value=created_col)
+    db.collection = MagicMock(return_value=MagicMock())
+
+    assert db.ensure_col("sensors") is created_col
+    db.create_collection.assert_called_with("sensors", edge=False)
+
+    db.has_collection.return_value = True
+    assert db.ensure_col("sensors") is db.collection.return_value
+
+
+def test_get_col_none():
+    db = BridgeDB.__new__(BridgeDB)
+    db.has_collection = MagicMock(return_value=False)
+    db.collection = MagicMock()
+
+    assert db.get_col("nope") is None
+    db.collection.assert_not_called()

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,40 @@
+import os
+from unittest.mock import MagicMock
+
+import ha_rag_bridge.bootstrap as boot
+
+
+def setup_env():
+    os.environ["ARANGO_URL"] = "http://db"
+    os.environ["ARANGO_USER"] = "root"
+    os.environ["ARANGO_PASS"] = "pass"
+    os.environ["AUTO_BOOTSTRAP"] = "1"
+
+
+def test_meta_collection_created(monkeypatch):
+    setup_env()
+    meta_col = MagicMock()
+    meta_col.get.return_value = None
+
+    def ensure_col(name, *, edge=False):
+        assert name == "meta"
+        return meta_col
+
+    db = MagicMock()
+    db.ensure_col.side_effect = ensure_col
+    db.collections.return_value = []
+    db.has_view.return_value = True
+
+    sys_db = MagicMock()
+    sys_db.has_database.return_value = True
+    client = MagicMock()
+
+    def db_side(name, **kw):
+        return sys_db if name == "_system" else db
+
+    client.db.side_effect = db_side
+    monkeypatch.setattr(boot, "ArangoClient", MagicMock(return_value=client))
+
+    boot.bootstrap()
+    assert meta_col.insert.called
+


### PR DESCRIPTION
## Summary
- add `BridgeDB` wrapper with `get_col` and `ensure_col`
- update bootstrap to use `BridgeDB` and ensure `meta` collection
- switch index creation to `add_index`
- adjust migration rename script
- document Python client usage
- add unit tests for adapter and meta bootstrap

## Testing
- `pip install -e .`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1319d1708327b05648dbf1cc30fc