### PR TITLE
Update Arango index API usage

### DIFF
--- a/ha_rag_bridge/db/index.py
+++ b/ha_rag_bridge/db/index.py
@@ -8,7 +8,7 @@ class IndexManager:
     def ensure_hash(self, fields, *, unique=False, sparse=True):
         indexes = self.coll.indexes()
         if not any(i["type"] == "hash" and i["fields"] == fields for i in indexes):
-            self.coll.indexes.create.hash(fields=fields, unique=unique, sparse=sparse)
+            self.coll.add_hash_index(fields=fields, unique=unique, sparse=sparse)
 
     def ensure_ttl(self, field, expire_after):
         indexes = self.coll.indexes()
@@ -18,8 +18,13 @@ class IndexManager:
     def ensure_vector(self, field, *, dimensions: int, metric: str = "cosine"):
         indexes = self.coll.indexes()
         if not any(i["type"] == "vector" and i["fields"] == [field] for i in indexes):
-            self.coll.indexes.create.hnsw(
-                fields=[field], dimensions=dimensions, similarity=metric
+            self.coll.add_index(
+                {
+                    "type": "vector",
+                    "fields": [field],
+                    "dimension": dimensions,
+                    "metric": metric,
+                }
             )
 
     # --- Persistent (skiplist) ---
@@ -28,6 +33,6 @@ class IndexManager:
         if not any(
             idx["type"] == "persistent" and idx["fields"] == fields for idx in indexes
         ):
-            self.coll.indexes.create.persistent(
+            self.coll.add_persistent_index(
                 fields=fields, unique=unique, sparse=sparse
             )

--- a/tests/test_index_manager.py
+++ b/tests/test_index_manager.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock
 def test_hnsw_created():
     coll = MagicMock()
     coll.indexes.return_value = []
-    coll.indexes.create.hnsw = MagicMock()
+    coll.add_index = MagicMock()
     mgr = IndexManager(coll)
     mgr.ensure_vector("vec", dimensions=3)
-    coll.indexes.create.hnsw.assert_called_once_with(
-        fields=["vec"], dimensions=3, similarity="cosine"
+    coll.add_index.assert_called_once_with(
+        {"type": "vector", "fields": ["vec"], "dimension": 3, "metric": "cosine"}
     )


### PR DESCRIPTION
## Summary
- switch index creation calls to `add_*` API
- adjust reindex logic to use dictionary-style indexes info
- update tests for new arango API

## Testing
- `ruff check .`
- `pytest -q`
- `coverage run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eb22752e08327943fee2b5d2b6cdc