### PR TITLE
Fix TTL index args for python-arango 8

### DIFF
--- a/ha_rag_bridge/db/index.py
+++ b/ha_rag_bridge/db/index.py
@@ -13,7 +13,7 @@ class IndexManager:
     def ensure_ttl(self, field, expire_after):
         indexes = self.coll.indexes()
         if not any(i["type"] == "ttl" and i["fields"] == [field] for i in indexes):
-            self.coll.add_ttl_index(field=field, expire_after=expire_after)
+            self.coll.add_ttl_index(fields=[field], expiry_time=expire_after)
 
     def ensure_vector(self, field, *, dimensions: int, metric: str = "cosine"):
         indexes = self.coll.indexes()


### PR DESCRIPTION
## Summary
- correct fields/expiry_time names in TTL index creation

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f667f6ad88327b48fde5b71f376a0