### PR TITLE
Fix vector and hash index checks

### DIFF
--- a/ha_rag_bridge/db/index.py
+++ b/ha_rag_bridge/db/index.py
@@ -8,7 +8,8 @@ class IndexManager:
     def ensure_hash(self, fields, *, unique=False, sparse=True):
         indexes = self.coll.indexes()
         if not any(
-            i["type"] == "persistent" and i["fields"] == fields for i in indexes
+            i["type"] in ("hash", "persistent") and i["fields"] == fields
+            for i in indexes
         ):
             self.coll.add_persistent_index(
                 fields=fields, unique=unique, sparse=sparse
@@ -26,8 +27,7 @@ class IndexManager:
                 {
                     "type": "vector",
                     "fields": [field],
-                    "dimension": dimensions,
-                    "metric": metric,
+                    "params": {"dimension": dimensions, "metric": metric},
                 }
             )
 
@@ -35,7 +35,8 @@ class IndexManager:
     def ensure_persistent(self, fields, unique=False, sparse=True):
         indexes = self.coll.indexes()
         if not any(
-            idx["type"] == "persistent" and idx["fields"] == fields for idx in indexes
+            idx["type"] in ("hash", "persistent") and idx["fields"] == fields
+            for idx in indexes
         ):
             self.coll.add_persistent_index(
                 fields=fields, unique=unique, sparse=sparse

--- a/tests/test_index_manager.py
+++ b/tests/test_index_manager.py
@@ -9,5 +9,9 @@ def test_hnsw_created():
     mgr = IndexManager(coll)
     mgr.ensure_vector("vec", dimensions=3)
     coll.add_index.assert_called_once_with(
-        {"type": "vector", "fields": ["vec"], "dimension": 3, "metric": "cosine"}
+        {
+            "type": "vector",
+            "fields": ["vec"],
+            "params": {"dimension": 3, "metric": "cosine"},
+        }
     )


### PR DESCRIPTION
## Summary
- fix detection of hash/persistent indexes
- use `params` for vector index creation
- update tests

## Testing
- `pytest -q`
- `ruff check .`
- `pytest --cov=ha_rag_bridge -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9982be108327a098ba456e70e72e