### PR TITLE
GH-912 vector index nLists fix

### DIFF
--- a/tests/test_index_manager.py
+++ b/tests/test_index_manager.py
@@ -6,12 +6,18 @@ def test_hnsw_created():
     coll = MagicMock()
     coll.indexes.return_value = []
     coll.add_index = MagicMock()
+    coll.count.return_value = 0
     mgr = IndexManager(coll)
     mgr.ensure_vector("vec", dimensions=3)
     coll.add_index.assert_called_once_with(
         {
             "type": "vector",
             "fields": ["vec"],
-            "params": {"dimension": 3, "metric": "cosine"},
+            "params": {
+                "metric": "cosine",
+                "dimension": 3,
+                "nLists": 1,
+                "defaultNProbe": 1,
+            },
         }
     )


### PR DESCRIPTION
## Summary
- add `n_lists` and `default_nprobe` args to `ensure_vector`
- include `nLists` in index JSON and heuristically compute when omitted
- consider both `hash` and `persistent` indexes in `ensure_hash`
- update unit tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fa058749c8327959986f19ae46ad3