### PR TITLE
Fix vector index defaults

### DIFF
--- a/tests/test_index_manager.py
+++ b/tests/test_index_manager.py
@@ -17,7 +17,7 @@ def test_hnsw_created():
                 "metric": "cosine",
                 "dimension": 3,
                 "nLists": 1,
-                "defaultNProbe": 1,
+                "defaultNProbe": 4,
             },
         }
     )


### PR DESCRIPTION
## Summary
- add default constants for vector index configuration
- ensure vector index uses heuristics when values missing
- update test expectations for new defaults

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for optional deps)*
- `coverage run -m pytest tests/test_index_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fac867d3c8327ae3098d9c846b426