### PR TITLE
Fix vector index creation for empty collections

### DIFF
--- a/tests/test_index_manager.py
+++ b/tests/test_index_manager.py
@@ -6,9 +6,10 @@ def test_hnsw_created():
     coll = MagicMock()
     coll.indexes.return_value = []
     coll.add_index = MagicMock()
-    coll.count.return_value = 0
+    coll.count.return_value = 30
     mgr = IndexManager(coll)
-    mgr.ensure_vector("vec", dimensions=3)
+    created = mgr.ensure_vector("vec", dimensions=3)
+    assert created is True
     coll.add_index.assert_called_once_with(
         {
             "type": "vector",
@@ -16,8 +17,19 @@ def test_hnsw_created():
             "params": {
                 "metric": "cosine",
                 "dimension": 3,
-                "nLists": 1,
+                "nLists": 30,
                 "defaultNProbe": 4,
             },
         }
     )
+
+
+def test_vector_skip_empty():
+    coll = MagicMock()
+    coll.indexes.return_value = []
+    coll.add_index = MagicMock()
+    coll.count.return_value = 0
+    mgr = IndexManager(coll)
+    created = mgr.ensure_vector("vec", dimensions=3)
+    assert created is False
+    coll.add_index.assert_not_called()


### PR DESCRIPTION
## Summary
- handle empty collection in vector index creation
- cap `nLists` and `defaultNProbe` by document count
- return boolean from `ensure_vector`
- adjust tests for new behaviour

## Testing
- `ruff check .`
- `pytest -q`
- `pytest -q --cov=ha_rag_bridge --cov=app`

------
https://chatgpt.com/codex/tasks/task_e_687fb407e13c8327afdb0879b4b7848c