### PR TITLE
feat(ha_rag_expose_api): add custom component

### DIFF
--- a/custom_components/ha_rag_expose_api/__init__.py
+++ b/custom_components/ha_rag_expose_api/__init__.py
@@ -1,0 +1,36 @@
+"""HA-RAG Expose API custom component."""
+
+from __future__ import annotations
+
+from .http import StaticEntitiesView, StateEntitiesView
+
+
+async def async_setup(hass, config):
+    """Set up the component."""
+    _register_views(hass)
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up from a config entry."""
+    _register_views(hass)
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return True
+
+
+async def async_reload_entry(hass, entry):
+    """Reload the config entry."""
+    await async_unload_entry(hass, entry)
+    await async_setup_entry(hass, entry)
+
+
+def _register_views(hass):
+    """Register HTTP views with Home Assistant if possible."""
+    http = getattr(hass, "http", None)
+    if hasattr(http, "register_view"):
+        http.register_view(StaticEntitiesView)
+        http.register_view(StateEntitiesView)

--- a/custom_components/ha_rag_expose_api/config_flow.py
+++ b/custom_components/ha_rag_expose_api/config_flow.py
@@ -1,0 +1,28 @@
+"""Config flow for the HA-RAG Expose API component."""
+
+from __future__ import annotations
+
+try:
+    from homeassistant import config_entries
+except Exception:  # pragma: no cover - Home Assistant not available
+    from types import SimpleNamespace
+
+    class DummyFlow:  # pragma: no cover - fallback
+        async def async_show_form(self, step_id: str, data_schema=None):
+            return {"type": "form", "step_id": step_id}
+
+        async def async_create_entry(self, title: str, data: dict):
+            return {"type": "create_entry", "title": title, "data": data}
+
+    config_entries = SimpleNamespace(ConfigFlow=DummyFlow)
+
+from .const import DOMAIN
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for the component."""
+
+    async def async_step_user(self, user_input=None):  # pragma: no cover - simple
+        if user_input is not None:
+            return self.async_create_entry(title="HA-RAG Expose API", data={})
+        return self.async_show_form(step_id="user")

--- a/custom_components/ha_rag_expose_api/const.py
+++ b/custom_components/ha_rag_expose_api/const.py
@@ -1,0 +1,3 @@
+"""Constants for the HA-RAG Expose API component."""
+
+DOMAIN = "ha_rag_expose_api"

--- a/custom_components/ha_rag_expose_api/http.py
+++ b/custom_components/ha_rag_expose_api/http.py
@@ -1,0 +1,41 @@
+"""HTTP views for the HA-RAG Expose API component."""
+
+from __future__ import annotations
+
+try:
+    from homeassistant.components.http import HomeAssistantView
+except Exception:  # pragma: no cover - Home Assistant not available
+    class HomeAssistantView:
+        """Fallback class used when Home Assistant is not installed."""
+
+        url: str = ""
+        name: str = ""
+        requires_auth: bool = True
+
+        async def get(self, request):
+            raise NotImplementedError
+
+        def json(self, result: dict, status_code: int = 200):  # type: ignore[override]
+            return result
+
+
+class StaticEntitiesView(HomeAssistantView):
+    """Return dummy data describing entities."""
+
+    url = "/api/rag/static/entities"
+    name = "api:rag:static_entities"
+    requires_auth = False
+
+    async def get(self, request):  # pragma: no cover - no real request in tests
+        return self.json({"areas": [], "devices": [], "entities": []})
+
+
+class StateEntitiesView(HomeAssistantView):
+    """Placeholder for state data."""
+
+    url = "/api/rag/state/entities"
+    name = "api:rag:state_entities"
+    requires_auth = False
+
+    async def get(self, request):  # pragma: no cover - no real request in tests
+        return self.json({"error": "not implemented"}, status_code=501)

--- a/custom_components/ha_rag_expose_api/manifest.json
+++ b/custom_components/ha_rag_expose_api/manifest.json
@@ -1,0 +1,6 @@
+{
+  "domain": "ha_rag_expose_api",
+  "name": "HA-RAG Expose API",
+  "version": "0.0.1",
+  "requirements": []
+}

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import pytest
+
+from custom_components.ha_rag_expose_api import async_setup
+
+
+@pytest.mark.asyncio
+async def test_async_setup_returns_true():
+    assert await async_setup(object(), {}) is True


### PR DESCRIPTION
## Summary
- implement new `ha_rag_expose_api` custom component
- expose dummy endpoints for static/state entity data
- add config flow skeleton
- provide minimal test for component setup

## Testing
- `ruff check .`
- `pytest -q tests/test_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_6882a9db5f9c8327b14a9c7612dd7f8f