### PR TITLE
Fix config flow entry creation for HA

### DIFF
--- a/custom_components/ha_rag_expose_api/config_flow.py
+++ b/custom_components/ha_rag_expose_api/config_flow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 try:
     from homeassistant import config_entries
 except Exception:  # pragma: no cover - Home Assistant not available
@@ -44,7 +46,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return duplicate
         if user_input is not None:
             ConfigFlow._configured = True
-            return await self.async_create_entry(title="HA-RAG Expose API", data={})
+            result = self.async_create_entry(title="HA-RAG Expose API", data={})
+            if inspect.isawaitable(result):
+                result = await result
+            return result
         return self.async_show_form(step_id="user")
 
     async def async_step_import(self, user_input):
@@ -52,4 +57,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if duplicate:
             return duplicate
         ConfigFlow._configured = True
-        return await self.async_create_entry(title="HA-RAG Expose API", data={})
+        result = self.async_create_entry(title="HA-RAG Expose API", data={})
+        if inspect.isawaitable(result):
+            result = await result
+        return result


### PR DESCRIPTION
## Summary
- handle `ConfigFlow.async_create_entry` being sync or async
- tweak tests for config flow

## Testing
- `PYTHONPATH=. pytest tests/test_config_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68839bf6e7b88327a242b1a90985933b