### PR TITLE
HAEXP-2 implement static entities endpoint

### DIFF
--- a/custom_components/ha_rag_expose_api/http.py
+++ b/custom_components/ha_rag_expose_api/http.py
@@ -2,6 +2,19 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+try:
+    from homeassistant.helpers import (
+        area_registry,
+        device_registry,
+        entity_registry,
+    )
+except Exception:  # pragma: no cover - Home Assistant not available
+    _helpers = None
+else:
+    _helpers = (area_registry, device_registry, entity_registry)
+
 try:
     from homeassistant.components.http import HomeAssistantView
 except Exception:  # pragma: no cover - Home Assistant not available
@@ -27,7 +40,12 @@ class StaticEntitiesView(HomeAssistantView):
     requires_auth = False
 
     async def get(self, request):  # pragma: no cover - no real request in tests
-        return self.json({"areas": [], "devices": [], "entities": []})
+        if _helpers is None:
+            return self.json({"areas": [], "devices": [], "entities": []})
+
+        hass = request.app["hass"]
+        data = _collect_static(hass)
+        return self.json(data)
 
 
 class StateEntitiesView(HomeAssistantView):
@@ -39,3 +57,46 @@ class StateEntitiesView(HomeAssistantView):
 
     async def get(self, request):  # pragma: no cover - no real request in tests
         return self.json({"error": "not implemented"}, status_code=501)
+
+
+def _collect_static(hass: Any) -> dict[str, list[dict[str, Any]]]:
+    """Collect static registry data from Home Assistant."""
+    area_mod, device_mod, entity_mod = _helpers  # type: ignore[misc]
+    area_reg = area_mod.async_get(hass)
+    device_reg = device_mod.async_get(hass)
+    entity_reg = entity_mod.async_get(hass)
+
+    areas = [
+        {
+            "id": area.id,
+            "name": area.name,
+            "floor": getattr(area, "floor_id", getattr(area, "floor", None)),
+            "aliases": list(getattr(area, "aliases", [])),
+        }
+        for area in area_reg.async_list_areas()
+    ]
+
+    devices = [
+        {
+            "id": device.id,
+            "name": device.name,
+            "model": device.model,
+            "manufacturer": device.manufacturer,
+            "area_id": device.area_id,
+        }
+        for device in device_reg.devices.values()
+    ]
+
+    entities = [
+        {
+            "entity_id": ent.entity_id,
+            "platform": ent.platform,
+            "device_id": ent.device_id,
+            "area_id": ent.area_id,
+            "domain": ent.domain,
+            "original_name": ent.original_name,
+        }
+        for ent in entity_reg.entities.values()
+    ]
+
+    return {"areas": areas, "devices": devices, "entities": entities}

--- a/tests/test_static_entities.py
+++ b/tests/test_static_entities.py
@@ -1,0 +1,86 @@
+import pytest
+
+from custom_components.ha_rag_expose_api import http
+from custom_components.ha_rag_expose_api.http import StaticEntitiesView
+
+
+class FakeReq:
+    def __init__(self, hass):
+        self.app = {"hass": hass}
+
+
+class FakeModule:
+    def __init__(self, reg):
+        self._reg = reg
+
+    def async_get(self, hass):
+        return self._reg
+
+
+class Area:
+    def __init__(self, id, name, floor=None, aliases=None):
+        self.id = id
+        self.name = name
+        self.floor = floor
+        self.aliases = aliases or []
+
+
+class Device:
+    def __init__(self, id, name, model, manufacturer, area_id=None):
+        self.id = id
+        self.name = name
+        self.model = model
+        self.manufacturer = manufacturer
+        self.area_id = area_id
+
+
+class Entity:
+    def __init__(self, entity_id, platform, device_id=None, area_id=None, domain=None, original_name=None):
+        self.entity_id = entity_id
+        self.platform = platform
+        self.device_id = device_id
+        self.area_id = area_id
+        self.domain = domain
+        self.original_name = original_name
+
+
+class FakeAreaReg:
+    def __init__(self, areas):
+        self._areas = {a.id: a for a in areas}
+
+    def async_list_areas(self):
+        return list(self._areas.values())
+
+
+class FakeDeviceReg:
+    def __init__(self, devices):
+        self.devices = {d.id: d for d in devices}
+
+
+class FakeEntityReg:
+    def __init__(self, entities):
+        self.entities = {e.entity_id: e for e in entities}
+
+
+@pytest.mark.asyncio
+async def test_static_entities(monkeypatch):
+    areas = [
+        Area("a1", "Kitchen", "f1", ["kitchen"]),
+        Area("a2", "Living", "f1"),
+        Area("a3", "Hall"),
+    ]
+    area_reg = FakeAreaReg(areas)
+    device = Device("d1", "Lamp", "L1", "Acme", area_id="a1")
+    dev_reg = FakeDeviceReg([device])
+    ent1 = Entity("light.lamp", "light", device_id="d1", area_id="a1", domain="light", original_name="Lamp")
+    ent2 = Entity("sensor.temp", "sensor", area_id="a2", domain="sensor", original_name="Temp")
+    ent_reg = FakeEntityReg([ent1, ent2])
+
+    monkeypatch.setattr(http, "_helpers", (FakeModule(area_reg), FakeModule(dev_reg), FakeModule(ent_reg)))
+
+    hass = object()
+    res = await StaticEntitiesView().get(FakeReq(hass))
+
+    assert len(res["areas"]) == 3
+    assert len(res["devices"]) == 1
+    assert len(res["entities"]) == 2


### PR DESCRIPTION
## Summary
- implement `_collect_static` function to query Home Assistant registries
- populate `/api/rag/static/entities` with real data when HA is available
- skip ArangoDB health check via env var for tests
- add unit test covering static entities view

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a3b49d388327b8ee4b11961487d5