### PR TITLE
Add HA devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,11 @@
 {
     "name": "ha-rag-bridge",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
-    "forwardPorts": [8000],
+    "image": "ghcr.io/home-assistant/devcontainer:stable",
+    "dockerComposeFile": [
+        "../docker-compose.yml",
+        "../docker-compose.dev.yml"
+    ],
+    "service": "homeassistant",
+    "forwardPorts": [8000, 8123, 5678],
     "postCreateCommand": "poetry install"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach Bridge",
+            "type": "python",
+            "request": "attach",
+            "connect": {"host": "localhost", "port": 5678},
+            "pathMappings": [
+                {"localRoot": "${workspaceFolder}", "remoteRoot": "/app"}
+            ]
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,16 @@ migrate:
 .PHONY: docs
 docs: docs/architecture.svg
 
+
+COMPOSE_DEV = docker-compose -f docker-compose.yml -f docker-compose.dev.yml
+
+.PHONY: dev-up dev-down dev-shell
+
+dev-up:
+	$(COMPOSE_DEV) up -d
+
+dev-down:
+	$(COMPOSE_DEV) down
+
+dev-shell:
+	$(COMPOSE_DEV) exec homeassistant bash

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ vector search works correctly.
 - python-arango 8.x
 - Rust toolchain for building pydantic-core
 
+## Dev container
+
+Run `make dev-up` to launch Home Assistant, the bridge with hot reload and a local ArangoDB instance. VS Code can attach to the running bridge via the **Attach Bridge** debug configuration. Stop all services with `make dev-down`.
+
 ## Bootstrap CLI
 
 After installing via Poetry or pulling the Docker image you can run the

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,38 @@
+version: "3.8"
+services:
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    ports:
+      - "8123:8123"
+    volumes:
+      - ha_config:/config
+    privileged: true
+  bridge:
+    build: .
+    command: >
+      python -m debugpy --listen 0.0.0.0:5678 -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 --log-config docker/uvicorn_log.ini
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+      - "5678:5678"
+    environment:
+      - EMBEDDING_BACKEND=gemini
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - GEMINI_OUTPUT_DIM=1536
+      - EMBED_DIM=1536
+      - ADMIN_TOKEN=${ADMIN_TOKEN}
+      - AUTO_BOOTSTRAP=1
+    depends_on:
+      - arangodb
+  arangodb:
+    image: arangodb:3.11
+    ports:
+      - "18529:8529"
+    environment:
+      - ARANGO_NO_AUTH=1
+    volumes:
+      - arangodb_dev:/var/lib/arangodb3
+volumes:
+  arangodb_dev:
+  ha_config:


### PR DESCRIPTION
## Summary
- integrate official Home Assistant devcontainer via docker compose
- launch bridge under debugpy and provide attach config
- include local ArangoDB service for development
- add convenience make targets

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883ab933ac08327939fd597b32b2a21