### PR TITLE
Fix graph bootstrap DB handling

### DIFF
--- a/ha_rag_bridge/bootstrap/__init__.py
+++ b/ha_rag_bridge/bootstrap/__init__.py
@@ -114,16 +114,24 @@ def _bootstrap_impl(
             nLists = 100
             doc_count = entity.count()
             if doc_count < nLists:
-                logger.info(f"Skip vector index – not enough documents in entity (have {doc_count}, need at least {nLists})")
+                logger.info(
+                    f"Skip vector index – not enough documents in entity (have {doc_count}, need at least {nLists})"
+                )
             else:
                 entity.add_index(
                     {
                         "type": "vector",
                         "fields": ["embedding"],
-                        "params": {"dimension": embed_dim, "metric": "cosine", "nLists": nLists},
+                        "params": {
+                            "dimension": embed_dim,
+                            "metric": "cosine",
+                            "nLists": nLists,
+                        },
                     }
                 )
-                logger.info(f"Created vector index on entity.embedding with nLists={nLists}")
+                logger.info(
+                    f"Created vector index on entity.embedding with nLists={nLists}"
+                )
         except Exception as exc:
             logger.error("Failed to create vector index", error=str(exc))
 
@@ -172,9 +180,7 @@ def _bootstrap_impl(
                     "entity": {
                         "includeAllFields": False,
                         "storeValues": "none",
-                        "fields": {
-                            "text": {"analyzers": ["text_en"]}
-                        },
+                        "fields": {"text": {"analyzers": ["text_en"]}},
                         "features": ["frequency", "norm", "position"],
                     }
                 }
@@ -189,9 +195,7 @@ def _bootstrap_impl(
                     "document": {
                         "includeAllFields": False,
                         "storeValues": "none",
-                        "fields": {
-                            "text": {"analyzers": ["text_en"]}
-                        },
+                        "fields": {"text": {"analyzers": ["text_en"]}},
                         "features": ["frequency", "norm", "position"],
                     }
                 }
@@ -199,4 +203,8 @@ def _bootstrap_impl(
         )
 
     meta_col.insert({"_key": "schema_version", "value": SCHEMA_LATEST}, overwrite=True)
+
+    from .__main__ import ensure_arango_graph
+
+    ensure_arango_graph()
     logger.info("bootstrap finished")

--- a/ha_rag_bridge/bootstrap/__main__.py
+++ b/ha_rag_bridge/bootstrap/__main__.py
@@ -10,7 +10,7 @@ def ensure_arango_graph():
     logger = get_logger(__name__)
     try:
         arango_url = os.environ["ARANGO_URL"]
-        db_name = os.getenv("ARANGO_DB", "_system")
+        db_name = os.getenv("ARANGO_DB", "ha_graph")
         logger.info("Connecting to ArangoDB", url=arango_url, database=db_name)
         db = ArangoClient(hosts=arango_url).db(
             db_name,

--- a/ha_rag_bridge/bootstrap/cli.py
+++ b/ha_rag_bridge/bootstrap/cli.py
@@ -21,7 +21,7 @@ def _reindex(
     try:
         arango = ArangoClient(hosts=os.environ["ARANGO_URL"])
         db = arango.db(
-            os.getenv("ARANGO_DB", "_system"),
+            os.getenv("ARANGO_DB", "ha_graph"),
             username=os.environ["ARANGO_USER"],
             password=os.environ["ARANGO_PASS"],
         )

--- a/tests/test_graph_bootstrap.py
+++ b/tests/test_graph_bootstrap.py
@@ -1,0 +1,42 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+import ha_rag_bridge.bootstrap as boot
+
+from tests.test_bootstrap import setup_env
+
+
+def test_graph_bootstrap(monkeypatch):
+    setup_env()
+
+    meta_col = MagicMock()
+    meta_col.get.return_value = None
+
+    db = MagicMock()
+    db.ensure_col.return_value = meta_col
+    db.collections.return_value = []
+    db.has_view.return_value = True
+
+    sys_db = MagicMock()
+    sys_db.has_database.return_value = True
+
+    client = MagicMock()
+    client.db.side_effect = lambda name, **kw: sys_db if name == "_system" else db
+
+    monkeypatch.setattr(boot, "ArangoClient", MagicMock(return_value=client))
+
+    fake_main = types.ModuleType("ha_rag_bridge.bootstrap.__main__")
+    called = {}
+
+    def fake_ensure():
+        called["yes"] = True
+        db.has_graph("ha_entity_graph")
+
+    fake_main.ensure_arango_graph = fake_ensure
+    sys.modules["ha_rag_bridge.bootstrap.__main__"] = fake_main
+
+    boot.bootstrap()
+
+    assert called.get("yes")
+    db.has_graph.assert_called_once_with("ha_entity_graph")


### PR DESCRIPTION
## Summary
- ensure `ha_rag_bridge.bootstrap._bootstrap_impl()` creates the graph
- use `ha_graph` as default DB everywhere in bootstrap
- add test for graph creation
- keep code formatted via Black

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6887ef7c86148327bb5d06a5b23c0362