### PR TITLE
Update ingest pipeline for areas/devices

### DIFF
--- a/custom_components/ha_rag_expose_api/http.py
+++ b/custom_components/ha_rag_expose_api/http.py
@@ -48,7 +48,11 @@ class StaticEntitiesView(HomeAssistantView):
 
         hass = request.app["hass"]
         # Check if 'all' parameter is provided to return all entities/devices
-        include_all = request.query.get("all", "").lower() in ("true", "1", "yes")
+        query = getattr(request, "query", None)
+        if query is None:
+            include_all = True
+        else:
+            include_all = query.get("all", "").lower() in ("true", "1", "yes")
         data = _collect_static(hass, include_all=include_all)
         return self.json(data)
 


### PR DESCRIPTION
## Summary
- ingest all areas and devices from static entity payload
- infer missing entity areas via device map
- store device name/model/manufacturer
- add fallback HTTP mode for `GeminiBackend`
- fix expose API when request has no query
- test ingest with devices/areas

## Testing
- `ruff check scripts/embedding_backends.py custom_components/ha_rag_expose_api/http.py tests/test_ingest.py tests/test_ingest_devices_areas.py scripts/ingest.py && black --check scripts/embedding_backends.py custom_components/ha_rag_expose_api/http.py scripts/ingest.py tests/test_ingest.py tests/test_ingest_devices_areas.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688874926c0c8327b47facfcc3238268