### PR TITLE
Add Typer CLI skeleton

### DIFF
--- a/ha_rag_bridge/__init__.py
+++ b/ha_rag_bridge/__init__.py
@@ -1,1 +1,17 @@
+from __future__ import annotations
+
 __version__ = "0.14.0"
+
+
+def run_ingest(path: str) -> None:
+    """Wrapper to run the ingest pipeline."""
+    from .ingest import run
+
+    run(path)
+
+
+def query(question: str, top_k: int = 3):
+    """Proxy to the pipeline query API."""
+    from .pipeline import query as pipeline_query
+
+    return pipeline_query(question, top_k=top_k)

--- a/ha_rag_bridge/cli/__init__.py
+++ b/ha_rag_bridge/cli/__init__.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import sys
+import typer
+
+__all__ = ["app", "main"]
+
+app = typer.Typer()
+
+
+@app.command()
+def ingest(path: str) -> None:
+    """Run the ingest pipeline for PATH."""
+    from ha_rag_bridge.ingest import run
+
+    run(path)
+
+
+@app.command()
+def query(question: str, top_k: int = typer.Option(3, '--top-k', '-k')) -> None:
+    """Query the RAG pipeline and output JSON."""
+    from ha_rag_bridge.pipeline import query as pipeline_query
+
+    result = pipeline_query(question, top_k=top_k)
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+
+
+def main(argv: list[str] | None = None) -> None:
+    app(prog_name="ha-rag", args=argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/ha_rag_bridge/ingest.py
+++ b/ha_rag_bridge/ingest.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def run(path: str) -> None:
+    """Ingest files from PATH (placeholder)."""
+    raise NotImplementedError

--- a/ha_rag_bridge/pipeline.py
+++ b/ha_rag_bridge/pipeline.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def query(question: str, top_k: int = 3):
+    """Query the RAG pipeline (placeholder)."""
+    raise NotImplementedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,11 @@ colorama = "^0.4"
 structlog = "^24"
 pydantic = "^2.7"
 google-genai = "^0.6.0"
+typer = "^0.12.3"
 
 [tool.poetry.scripts]
 ha-rag-bootstrap = "ha_rag_bridge.bootstrap.cli:main"
+ha-rag = "ha_rag_bridge.cli:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for ha_rag_bridge."""

--- a/tests/test_typer_cli.py
+++ b/tests/test_typer_cli.py
@@ -1,0 +1,40 @@
+"""Smoke-tests for the Typer CLI."""
+
+from typer.testing import CliRunner
+
+from ha_rag_bridge.cli import app
+
+
+runner = CliRunner()
+
+
+def test_query_smoke(monkeypatch):
+    """`ha-rag query` should call the pipeline and emit JSON."""
+
+    def _stubbed_query(question: str, top_k: int = 3):  # noqa: D401
+        # simple deterministic stub so we don't hit the real pipeline
+        return {"question": question, "answer": "ok", "top_k": top_k}
+
+    monkeypatch.setattr("ha_rag_bridge.pipeline.query", _stubbed_query)
+
+    result = runner.invoke(app, ["query", "Mi az a RAG?"])
+
+    assert result.exit_code == 0
+    assert '"answer": "ok"' in result.stdout
+
+
+def test_ingest_smoke(monkeypatch, tmp_path):
+    """`ha-rag ingest` should invoke the ingest pipeline without error."""
+
+    called = {"flag": False}
+
+    def _stubbed_run(path: str):  # noqa: D401
+        called["flag"] = True
+        assert path == str(tmp_path)
+
+    monkeypatch.setattr("ha_rag_bridge.ingest.run", _stubbed_run)
+
+    result = runner.invoke(app, ["ingest", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert called["flag"] is True


### PR DESCRIPTION
## Summary
- add ingest/query helpers in package init
- introduce a Typer-based `ha-rag` CLI with `ingest` and `query` commands
- expose `ha-rag` as console script and depend on Typer
- add smoke tests for CLI and stub modules
- export `app` and `main` via `__all__`

## Testing
- `ruff check .`
- `pytest -q tests/test_typer_cli.py`
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6888da72429083278964a2c76a0b3a7b