### PR TITLE
Add Streamlit playground

### DIFF
--- a/ha_rag_bridge/playground/__init__.py
+++ b/ha_rag_bridge/playground/__init__.py
@@ -1,0 +1,2 @@
+"""Interactive playground helpers (Streamlit & notebooks)."""
+

--- a/ha_rag_bridge/playground/streamlit_app.py
+++ b/ha_rag_bridge/playground/streamlit_app.py
@@ -1,0 +1,60 @@
+"""Minimal Streamlit UI to poke the RAG pipeline interactively."""
+
+from __future__ import annotations
+
+import json
+
+import streamlit as st
+
+from ha_rag_bridge import query as rag_query
+
+# --------------------------------------------------------------------------- #
+#  Page config & layout
+# --------------------------------------------------------------------------- #
+
+st.set_page_config(page_title="ha-rag-bridge Playground", page_icon="🧩", layout="centered")
+st.title("🧩 ha-rag-bridge Playground")
+st.caption("Gyors tesztfelület a retriever + prompt finomhangolásához.")
+
+# --------------------------------------------------------------------------- #
+#  Controls
+# --------------------------------------------------------------------------- #
+
+question = st.text_area("Kérdés", "Melyik eszköz felelős a hibrid rag-bridge-ért?")
+top_k = st.slider("top_k (találatok száma)", 1, 10, 3)
+
+if st.button("Futtatás"):
+    if not question.strip():
+        st.warning("Adj meg egy kérdést!")
+        st.stop()
+
+    with st.spinner("Lekérdezés…"):
+        response = rag_query(question, top_k=top_k)
+
+    # ----------------------------------------------------------------------- #
+    #  Results
+    # ----------------------------------------------------------------------- #
+    st.subheader("Válasz")
+    st.write(response.get("answer", "<nincs 'answer' mező>"))
+
+    with st.expander("ℹ️ Teljes JSON"):
+        st.json(response, expanded=False)
+
+# --------------------------------------------------------------------------- #
+#  Convenience CLI entry-point
+# --------------------------------------------------------------------------- #
+
+def main() -> None:  # pragma: no cover
+    """Run via `python -m ha_rag_bridge.playground.streamlit_app`."""
+    import subprocess
+    import sys
+    subprocess.run(
+        ["streamlit", "run", "-q", "-"],
+        input=__file__.encode(),
+        check=True,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/notebooks/poc_playground.py
+++ b/notebooks/poc_playground.py
@@ -1,0 +1,40 @@
+# ---
+# jupyter:
+#   jupytext_format_version: '1.3'
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # ha-rag-bridge Playground (Notebook)
+#
+# Rövid, önmagában futtatható notebook a retriever & prompt vizsgálatához.
+# 
+# * Kérdés megadása
+# * `top_k` paraméter állítása
+# * JSON kimenet megjelenítése
+
+# %%
+import json
+
+from ha_rag_bridge import query
+
+question = "Melyik eszköz felelős a hibrid rag-bridge-ért?"
+response = query(question)
+
+print(json.dumps(response, indent=2, ensure_ascii=False))
+
+# %%
+top_k = 5
+response = query(question, top_k=top_k)
+print(json.dumps(response, indent=2, ensure_ascii=False))
+
+# %% [markdown]
+# ## Prompt-preview
+# (ha a pipeline `prompt` kulcsot is visszaad)
+
+# %%
+print(response.get("prompt", "<nincs prompt mező>"))
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ ha-rag = "ha_rag_bridge.cli:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1"
+streamlit = "^1.34"
 pytest-asyncio = "^0.23"
 debugpy = "^1.6.0"
 pre-commit = "^2.20.0"

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -1,0 +1,18 @@
+"""Smoke-test: a Streamlit playground modulja hiba nélkül importálható."""
+
+import importlib
+
+import pytest
+
+
+pytest.importorskip("streamlit")
+
+
+def test_streamlit_app_import(monkeypatch):
+    """A streamlit modul betöltése ne fusson valódi lekérdezést."""
+
+    # dummy query → ne hívjuk a valódi pipeline-t
+    monkeypatch.setattr("ha_rag_bridge.query", lambda *_a, **_kw: {})
+
+    importlib.import_module("ha_rag_bridge.playground.streamlit_app")
+


### PR DESCRIPTION
## Summary
- add Streamlit dev dependency
- introduce a Streamlit based playground
- provide a simple notebook example
- smoke test the playground module

## Testing
- `pytest -q tests/test_playground.py`
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6888ed838c3883279e13c01c1e0d865b