### PR TITLE
Add eval harness & CI workflow

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,17 @@
+name: Eval
+
+on:
+  pull_request:
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install poetry
+      - run: poetry install
+      - run: cp .env.example .env
+      - run: poetry run ha-rag eval tests/fixtures/qa_pairs.json --threshold 0.2

--- a/ha_rag_bridge/cli/__init__.py
+++ b/ha_rag_bridge/cli/__init__.py
@@ -27,6 +27,21 @@ def query(question: str, top_k: int = typer.Option(3, '--top-k', '-k')) -> None:
     sys.stdout.write("\n")
 
 
+@app.command()
+def eval(dataset: str, threshold: float = typer.Option(0.2, "--threshold", "-t")) -> None:
+    """Run the evaluation harness on DATASET."""
+    from ha_rag_bridge.eval import run as eval_run
+
+    try:
+        score = eval_run(dataset, threshold)
+    except SystemExit as exc:
+        # A runner már eldöntötte, hogy siker (0) vagy bukás (1-től felfelé),
+        # propagáljuk ugyanazzal a kóddal a Typer exit-hez.
+        raise typer.Exit(code=exc.code)
+    else:
+        typer.echo(f"score={score:.3f}")
+
+
 def main(argv: list[str] | None = None) -> None:
     app(prog_name="ha-rag", args=argv)
 

--- a/ha_rag_bridge/eval/__init__.py
+++ b/ha_rag_bridge/eval/__init__.py
@@ -1,0 +1,3 @@
+from .runner import run
+
+__all__ = ["run"]

--- a/ha_rag_bridge/eval/metrics.py
+++ b/ha_rag_bridge/eval/metrics.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from rouge_score import rouge_scorer
+
+
+scorer = rouge_scorer.RougeScorer(["rougeL"], use_stemmer=True)
+
+
+def rouge_l_f1(system: str, reference: str) -> float:
+    """Return the Rouge-L F1 score for a single prediction."""
+    return scorer.score(reference, system)["rougeL"].fmeasure

--- a/ha_rag_bridge/eval/runner.py
+++ b/ha_rag_bridge/eval/runner.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .metrics import rouge_l_f1
+
+
+def run(dataset_path: str, threshold: float) -> float:
+    """Run evaluation on DATASET_PATH and return average score."""
+    from ha_rag_bridge.pipeline import query as pipeline_query
+
+    data = json.loads(Path(dataset_path).read_text())
+    scores = []
+    for item in data:
+        question = item["question"]
+        ref = item["reference"]
+        result = pipeline_query(question)
+        scores.append(rouge_l_f1(result.get("answer", ""), ref))
+
+    avg_score = sum(scores) / len(scores)
+    if avg_score < threshold:
+        raise SystemExit(1)
+    return avg_score

--- a/ha_rag_bridge/playground/streamlit_app.py
+++ b/ha_rag_bridge/playground/streamlit_app.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import streamlit as st
 
 from ha_rag_bridge import query as rag_query
@@ -47,7 +45,6 @@ if st.button("Futtatás"):
 def main() -> None:  # pragma: no cover
     """Run via `python -m ha_rag_bridge.playground.streamlit_app`."""
     import subprocess
-    import sys
     subprocess.run(
         ["streamlit", "run", "-q", "-"],
         input=__file__.encode(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ structlog = "^24"
 pydantic = "^2.7"
 google-genai = "^0.6.0"
 typer = "^0.12.3"
+rouge-score = "^0.1.2"
 
 [tool.poetry.scripts]
 ha-rag-bootstrap = "ha_rag_bridge.bootstrap.cli:main"

--- a/tests/fixtures/qa_pairs.json
+++ b/tests/fixtures/qa_pairs.json
@@ -1,0 +1,4 @@
+[
+  {"question": "Mi a neved?", "reference": "ChatGPT vagyok."},
+  {"question": "Hány lába van egy lónak?", "reference": "Egy lónak négy lába van."}
+]

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,32 @@
+from typer.testing import CliRunner
+
+from ha_rag_bridge.cli import app
+
+runner = CliRunner()
+
+dataset = "tests/fixtures/qa_pairs.json"
+
+
+def test_eval_success(monkeypatch):
+    mapping = {
+        "Mi a neved?": "ChatGPT vagyok.",
+        "Hány lába van egy lónak?": "Egy lónak négy lába van.",
+    }
+
+    def _query(question: str, top_k: int = 3):
+        return {"answer": mapping[question]}
+
+    monkeypatch.setattr("ha_rag_bridge.pipeline.query", _query)
+
+    result = runner.invoke(app, ["eval", dataset, "--threshold", "0.9"])
+    assert result.exit_code == 0
+
+
+def test_eval_failure(monkeypatch):
+    def _query(question: str, top_k: int = 3):
+        return {"answer": "irrelevant"}
+
+    monkeypatch.setattr("ha_rag_bridge.pipeline.query", _query)
+
+    result = runner.invoke(app, ["eval", dataset, "--threshold", "0.9"])
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- add Rouge-L metric and eval runner
- expose `ha-rag eval` CLI command
- integrate eval into CI
- add integration tests and fixtures
- clean unused imports
- propagate exit code correctly in eval CLI

## Testing
- `ruff check .`
- `pytest tests/test_eval.py tests/test_typer_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f1fac0dc8327a7d118386738b520